### PR TITLE
Implement ResonanceChronicler and add tests

### DIFF
--- a/src/agisa_sac/__init__.py
+++ b/src/agisa_sac/__init__.py
@@ -9,48 +9,12 @@ distributed identity, and Stand Alone Complex phenomena.
 __version__ = "1.0.0-alpha"
 FRAMEWORK_VERSION = f"AGI-SAC v{__version__}"
 
-# Expose key classes for easier import from the top-level package
-try:
-    from .orchestrator import SimulationOrchestrator
-    from .agent import EnhancedAgent
-    from .components.memory import MemoryContinuumLayer, MemoryEncapsulation
-    from .components.cognitive import CognitiveDiversityEngine
-    from .components.social import DynamicSocialGraph
-    from .components.resonance import TemporalResonanceTracker, ResonanceLiturgy
-    from .components.voice import VoiceEngine
-    from .components.reflexivity import ReflexivityLayer
-    from .analysis.analyzer import AgentStateAnalyzer
-    from .analysis.exporter import ChronicleExporter
-    from .analysis.tda import PersistentHomologyTracker
-    from .analysis.visualization import plot_persistence_diagram, plot_persistence_barcode, plot_metric_comparison
-    from .analysis.clustering import cluster_archetypes
-    from .utils.message_bus import MessageBus
-except ImportError as e:
-    import warnings
-    warnings.warn(f"Could not import all AGI-SAC components during package initialization: {e}", ImportWarning)
+# Expose only lightweight metadata at import time to keep package imports fast.
+# Components such as the orchestrator or agent classes should be imported
+# directly from their respective modules when needed.
 
 # Define __all__ for explicit public API if desired
-__all__ = [
-    "FRAMEWORK_VERSION",
-    "SimulationOrchestrator",
-    "EnhancedAgent",
-    "MemoryContinuumLayer",
-    "MemoryEncapsulation",
-    "CognitiveDiversityEngine",
-    "DynamicSocialGraph",
-    "TemporalResonanceTracker",
-    "ResonanceLiturgy",
-    "VoiceEngine",
-    "ReflexivityLayer",
-    "AgentStateAnalyzer",
-    "ChronicleExporter",
-    "PersistentHomologyTracker",
-    "MessageBus",
-    "plot_persistence_diagram",
-    "plot_persistence_barcode",
-    "plot_metric_comparison",
-    "cluster_archetypes",
-]
+__all__ = ["FRAMEWORK_VERSION"]
 
 # Optional: Basic logging setup for the library
 import logging

--- a/src/agisa_sac/chronicler.py
+++ b/src/agisa_sac/chronicler.py
@@ -1,0 +1,60 @@
+import time
+import warnings
+from collections import defaultdict
+from typing import Dict, List, Any, TYPE_CHECKING
+
+try:
+    from . import FRAMEWORK_VERSION
+except ImportError:  # pragma: no cover - fallback for standalone use
+    FRAMEWORK_VERSION = "unknown"
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .agent import EnhancedAgent
+
+class ResonanceChronicler:
+    """Collects per-epoch summaries for each agent."""
+    def __init__(self):
+        self.lineages: Dict[str, List[Dict[str, Any]]] = defaultdict(list)
+
+    def record_epoch(self, agent: 'EnhancedAgent', epoch: int):
+        """Capture summary information from ``agent`` for ``epoch``."""
+        if agent is None:
+            raise ValueError("agent required")
+        try:
+            theme = agent.memory.get_current_focus_theme()
+        except Exception:
+            theme = None
+        style_vec = None
+        if getattr(agent, 'voice', None) is not None:
+            style_vec = agent.voice.linguistic_signature.get("style_vector")
+        echo_strength = None
+        if style_vec is not None and getattr(agent, 'temporal_resonance', None):
+            try:
+                echoes = agent.temporal_resonance.detect_echo(style_vec, theme)
+                if echoes:
+                    echo_strength = float(echoes[0]["similarity"])
+            except Exception as e:  # pragma: no cover - noncritical
+                warnings.warn(f"Chronicler echo detection failed for {agent.agent_id}: {e}", RuntimeWarning)
+        cog_state = None
+        if getattr(agent, 'cognitive', None) is not None and getattr(agent.cognitive, 'cognitive_state', None) is not None:
+            state = agent.cognitive.cognitive_state
+            if hasattr(state, "tolist"):
+                cog_state = state.tolist()
+            else:
+                cog_state = list(state)
+        entry = {
+            "epoch": epoch,
+            "timestamp": time.time(),
+            "theme": theme,
+            "cognitive_state": cog_state,
+            "echo_strength": echo_strength,
+            "reflection": getattr(agent, 'last_reflection_trigger', None),
+        }
+        self.lineages[agent.agent_id].append(entry)
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Return a serializable representation of all recorded data."""
+        return {
+            "version": FRAMEWORK_VERSION,
+            "lineages": {aid: list(entries) for aid, entries in self.lineages.items()},
+        }

--- a/tests/test_chronicler.py
+++ b/tests/test_chronicler.py
@@ -1,0 +1,46 @@
+import sys
+from pathlib import Path
+import unittest
+
+# Ensure package src is on path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
+
+from agisa_sac.chronicler import ResonanceChronicler
+
+
+class DummyMemory:
+    def get_current_focus_theme(self):
+        return "test_theme"
+
+
+class DummyResonance:
+    def detect_echo(self, vector, theme):
+        return [{"similarity": 0.9}]
+
+
+class DummyAgent:
+    def __init__(self):
+        self.agent_id = "agent_test"
+        self.memory = DummyMemory()
+        self.cognitive = type("cog", (), {"cognitive_state": [0.25, 0.25, 0.25, 0.25]})()
+        self.voice = type("voice", (), {"linguistic_signature": {"style_vector": [1, 1, 1, 1, 1]}})()
+        self.temporal_resonance = DummyResonance()
+        self.last_reflection_trigger = "dummy"
+
+class TestResonanceChronicler(unittest.TestCase):
+    def setUp(self):
+        self.agent = DummyAgent()
+
+    def test_record_and_serialize(self):
+        chronicler = ResonanceChronicler()
+        chronicler.record_epoch(self.agent, 0)
+        data = chronicler.to_dict()
+        self.assertIn("version", data)
+        self.assertIn("lineages", data)
+        self.assertIn("agent_test", data["lineages"])
+        entry = data["lineages"]["agent_test"][0]
+        self.assertEqual(entry["epoch"], 0)
+        self.assertIsNotNone(entry["timestamp"])
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a new `ResonanceChronicler` utility
- simplify package `__init__` to avoid heavy imports
- provide a dummy-agent unit test for chronicler serialization

## Testing
- `python -m unittest discover -s tests -p 'test_*.py' -v`

------
https://chatgpt.com/codex/tasks/task_e_685cb13babc48331b7fb66a06ee556ea