### PR TITLE
Add basic tests and GitHub Actions

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,24 @@
+name: Python package
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+    - name: Test with pytest
+      run: |
+        pytest

--- a/tests/test_cognitive.py
+++ b/tests/test_cognitive.py
@@ -1,0 +1,23 @@
+import os
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+from agisa_sac.components.memory import MemoryContinuumLayer
+from agisa_sac.components.cognitive import CognitiveDiversityEngine
+
+def test_cognitive_decide_adds_memory():
+    memory = MemoryContinuumLayer(agent_id="A2", capacity=10, use_semantic=False)
+    engine = CognitiveDiversityEngine(
+        agent_id="A2",
+        personality={"curiosity":0.5,"conformity":0.5,"openness":0.5,"consistency":0.5},
+        memory_layer=memory
+    )
+    prev_count = len(memory.memories)
+    response = engine.decide("future plans", {"peer": 1.0})
+    assert response in [
+        "Approach A: Systematic",
+        "Approach B: Creative",
+        "Approach C: Balanced",
+        "Approach D: Efficient",
+    ]
+    assert len(memory.memories) == prev_count + 1
+    assert any(mem.content.get("type") == "decision_context" for mem in memory.memories.values())

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,12 @@
+import os
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+import time
+from agisa_sac.components.memory import MemoryContinuumLayer
+
+def test_memory_retrieval_term_search():
+    mem = MemoryContinuumLayer(agent_id="A1", capacity=10, use_semantic=False)
+    mid = mem.add_memory({"text": "the cat jumped over the moon", "type": "note"})
+    results = mem.retrieve_memory("cat")
+    assert any(r["memory_id"] == mid for r in results)
+    assert mem.memories[mid].access_count == 1

--- a/tests/test_resonance.py
+++ b/tests/test_resonance.py
@@ -1,0 +1,14 @@
+import os
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+import numpy as np
+import time
+from agisa_sac.components.resonance import TemporalResonanceTracker
+
+def test_resonance_detects_echo():
+    tracker = TemporalResonanceTracker(agent_id="A1", resonance_threshold=0.8)
+    past_vector = np.array([1.0, 0.0, 0.0])
+    tracker.record_state(time.time() - 5, past_vector, "theme")
+    echoes = tracker.detect_echo(np.array([1.0, 0.0, 0.0]), "theme")
+    assert echoes
+    assert echoes[0]["similarity"] >= 0.8


### PR DESCRIPTION
## Summary
- add basic pytest tests for memory, cognition, and resonance
- configure GitHub Actions workflow to run pytest on PRs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for numpy, SyntaxError in orchestrator)*

------
https://chatgpt.com/codex/tasks/task_e_685cb13d3fa88331aaed0201e26d9b89