### PR TITLE
Add scalable agent injection scaffold

### DIFF
--- a/mindlink_infra/README.md
+++ b/mindlink_infra/README.md
@@ -1,0 +1,5 @@
+# Mindlink Infrastructure
+
+This directory contains a reference implementation for scalable agent injection.
+It provides a FastAPI service for spawning agents at runtime and a Redis-based
+pub/sub wrapper for distributed communication.

--- a/mindlink_infra/__init__.py
+++ b/mindlink_infra/__init__.py
@@ -1,0 +1,6 @@
+"""Infrastructure tools for scalable agent injection."""
+
+from .registry import AgentRegistry
+from .pubsub import RedisPubSub
+
+__all__ = ["AgentRegistry", "RedisPubSub"]

--- a/mindlink_infra/api.py
+++ b/mindlink_infra/api.py
@@ -1,0 +1,22 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+from .registry import AgentRegistry
+
+app = FastAPI(title="Mindlink Infrastructure")
+registry = AgentRegistry()
+
+
+class AgentConfig(BaseModel):
+    agent_id: str
+    personality: dict = {}
+
+
+@app.post("/spawn_agent")
+async def spawn_agent(config: AgentConfig):
+    agent = registry.spawn_agent(config.agent_id, config.personality)
+    return {"status": "spawned", "agent_id": agent.agent_id}
+
+
+@app.get("/agents")
+async def list_agents():
+    return {"agents": registry.list_agents()}

--- a/mindlink_infra/pubsub.py
+++ b/mindlink_infra/pubsub.py
@@ -1,0 +1,26 @@
+import json
+from typing import Callable
+
+try:
+    import redis
+except ImportError:  # pragma: no cover - environment without redis
+    redis = None
+
+
+class RedisPubSub:
+    """Minimal Redis-based pub/sub wrapper."""
+    def __init__(self, url: str = "redis://localhost:6379/0"):
+        if redis is None:
+            raise RuntimeError("redis package not available")
+        self.redis = redis.Redis.from_url(url)
+        self.pubsub = self.redis.pubsub()
+
+    def publish(self, channel: str, message: dict) -> None:
+        self.redis.publish(channel, json.dumps(message))
+
+    def subscribe(self, channel: str, callback: Callable[[dict], None]) -> None:
+        def _handler(msg):
+            if msg['type'] == 'message':
+                callback(json.loads(msg['data']))
+        self.pubsub.subscribe(**{channel: _handler})
+        self.pubsub.run_in_thread(sleep_time=0.001)

--- a/mindlink_infra/registry.py
+++ b/mindlink_infra/registry.py
@@ -1,0 +1,19 @@
+from typing import Dict
+from agisa_sac.agent import EnhancedAgent
+
+class AgentRegistry:
+    """Simple in-memory registry for managing agents."""
+    def __init__(self):
+        self.agents: Dict[str, EnhancedAgent] = {}
+
+    def spawn_agent(self, agent_id: str, personality: Dict) -> EnhancedAgent:
+        """Create and store a new agent instance."""
+        agent = EnhancedAgent(agent_id=agent_id, personality=personality, capacity=50, use_semantic=False)
+        self.agents[agent_id] = agent
+        return agent
+
+    def get_agent(self, agent_id: str) -> EnhancedAgent | None:
+        return self.agents.get(agent_id)
+
+    def list_agents(self) -> list[str]:
+        return list(self.agents.keys())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "networkx",
     "sentence_transformers",
     "fastapi",
+    "redis",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- provide `mindlink_infra` with FastAPI spawn endpoint and Redis pub/sub helper
- add in-memory `AgentRegistry` for dynamic agent management
- document infrastructure in a new README
- include `redis` dependency for pub/sub support

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'agisa_sac')*

------
https://chatgpt.com/codex/tasks/task_e_685e28b41b28833195e6e28273d2d5ed