### PR TITLE
Add dynamic agent registry features

### DIFF
--- a/mindlink_infra/README.md
+++ b/mindlink_infra/README.md
@@ -1,0 +1,14 @@
+# Mindlink Infrastructure
+
+This directory contains infrastructure helpers for scalable agent injection.
+It exposes a FastAPI API for spawning agents and registering new agent
+implementations at runtime. A minimal Redis-based pub/sub wrapper is provided
+for distributed communication between agents or services.
+
+### Key Features
+
+- **Dynamic registry** – Agent classes can be loaded from dotted paths using the
+  API or programmatically via ``AgentRegistry.load_agent_class``.
+- **Spawn API** – ``/spawn_agent`` creates new agents on the fly.
+- **Type registration API** – ``/register_agent_type`` allows plugging in custom
+  agent classes without redeploying the service.

--- a/mindlink_infra/__init__.py
+++ b/mindlink_infra/__init__.py
@@ -1,0 +1,6 @@
+"""Infrastructure tools for scalable agent injection."""
+
+from .registry import AgentRegistry
+from .pubsub import RedisPubSub
+
+__all__ = ["AgentRegistry", "RedisPubSub"]

--- a/mindlink_infra/api.py
+++ b/mindlink_infra/api.py
@@ -1,0 +1,40 @@
+from fastapi import FastAPI
+from pydantic import BaseModel
+
+from .registry import AgentRegistry
+
+app = FastAPI(title="Mindlink Infrastructure")
+registry = AgentRegistry()
+
+
+class AgentConfig(BaseModel):
+    agent_id: str
+    personality: dict = {}
+    agent_type: str = "enhanced"
+
+
+class AgentTypeConfig(BaseModel):
+    """Configuration for registering a new agent class."""
+    path: str  # dotted path to class, e.g. "mypkg.module:CustomAgent"
+    name: str | None = None
+
+
+@app.post("/spawn_agent")
+async def spawn_agent(config: AgentConfig):
+    agent = registry.spawn_agent(
+        config.agent_id,
+        config.personality,
+        agent_type=config.agent_type,
+    )
+    return {"status": "spawned", "agent_id": agent.agent_id}
+
+
+@app.get("/agents")
+async def list_agents():
+    return {"agents": registry.list_agents()}
+
+
+@app.post("/register_agent_type")
+async def register_agent_type(cfg: AgentTypeConfig):
+    registry.load_agent_class(cfg.path, cfg.name)
+    return {"status": "registered"}

--- a/mindlink_infra/pubsub.py
+++ b/mindlink_infra/pubsub.py
@@ -1,0 +1,26 @@
+import json
+from typing import Callable
+
+try:
+    import redis
+except ImportError:  # pragma: no cover - environment without redis
+    redis = None
+
+
+class RedisPubSub:
+    """Minimal Redis-based pub/sub wrapper."""
+    def __init__(self, url: str = "redis://localhost:6379/0"):
+        if redis is None:
+            raise RuntimeError("redis package not available")
+        self.redis = redis.Redis.from_url(url)
+        self.pubsub = self.redis.pubsub()
+
+    def publish(self, channel: str, message: dict) -> None:
+        self.redis.publish(channel, json.dumps(message))
+
+    def subscribe(self, channel: str, callback: Callable[[dict], None]) -> None:
+        def _handler(msg):
+            if msg['type'] == 'message':
+                callback(json.loads(msg['data']))
+        self.pubsub.subscribe(**{channel: _handler})
+        self.pubsub.run_in_thread(sleep_time=0.001)

--- a/mindlink_infra/registry.py
+++ b/mindlink_infra/registry.py
@@ -1,0 +1,57 @@
+"""Runtime agent registry with dynamic loading capabilities."""
+
+from importlib import import_module
+from typing import Dict, Type
+
+from agisa_sac.agent import EnhancedAgent
+
+class AgentRegistry:
+    """Manage active agents and available agent types."""
+
+    def __init__(self) -> None:
+        self.agents: Dict[str, EnhancedAgent] = {}
+        self.agent_classes: Dict[str, Type[EnhancedAgent]] = {
+            "enhanced": EnhancedAgent
+        }
+
+    # ------------------------------------------------------------------
+    # Agent type registration
+    # ------------------------------------------------------------------
+
+    def register_agent_class(self, name: str, cls: Type[EnhancedAgent]) -> None:
+        """Register a new agent class for spawning."""
+        if not name:
+            raise ValueError("name must be non-empty")
+        self.agent_classes[name] = cls
+
+    def load_agent_class(self, dotted_path: str, name: str | None = None) -> None:
+        """Load and register an agent class from ``module:Class`` syntax."""
+        module_path, _, class_name = dotted_path.partition(":")
+        if not class_name:
+            # allow module.Class style
+            module_path, _, class_name = dotted_path.rpartition(".")
+        module = import_module(module_path)
+        cls = getattr(module, class_name)
+        self.register_agent_class(name or class_name.lower(), cls)
+
+    def spawn_agent(
+        self, agent_id: str, personality: Dict, *, agent_type: str = "enhanced"
+    ) -> EnhancedAgent:
+        """Create and store a new agent instance of ``agent_type``."""
+        cls = self.agent_classes.get(agent_type)
+        if cls is None:
+            raise ValueError(f"Unknown agent type: {agent_type}")
+        agent = cls(
+            agent_id=agent_id,
+            personality=personality,
+            capacity=50,
+            use_semantic=False,
+        )
+        self.agents[agent_id] = agent
+        return agent
+
+    def get_agent(self, agent_id: str) -> EnhancedAgent | None:
+        return self.agents.get(agent_id)
+
+    def list_agents(self) -> list[str]:
+        return list(self.agents.keys())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "networkx",
     "sentence_transformers",
     "fastapi",
+    "redis",
 ]
 
 [build-system]


### PR DESCRIPTION
## Summary
- extend `AgentRegistry` to support runtime loading of custom agent classes
- allow specifying agent type when spawning via the API
- document the new registration endpoint and dynamic registry capabilities

## Testing
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_685e28b41b28833195e6e28273d2d5ed