### PR TITLE
Fix analysis init and add test setup

### DIFF
--- a/src/agisa_sac/analysis/__init__.py
+++ b/src/agisa_sac/analysis/__init__.py
@@ -1,54 +1,33 @@
-  """Modules for analyzing simulation state and results."""
- 
- from .analyzer import AgentStateAnalyzer
- from .exporter import ChronicleExporter
- from .tda import PersistentHomologyTracker
- from .visualization import plot_persistence_diagram, plot_persistence_barcode, plot_metric_comparison
- from .clustering import cluster_archetypes
-+from ..metrics.monitoring import (
-+    compute_sri,
-+    compute_nds,
-+    compute_vsd,
-+    compute_mce,
-+    generate_monitoring_metrics,
-+)
- 
- __all__ = [
-     "AgentStateAnalyzer",
-     "ChronicleExporter",
-     "PersistentHomologyTracker",
-     "plot_persistence_diagram",
-     "plot_persistence_barcode",
-     "plot_metric_comparison",
-     "cluster_archetypes",
-+    "compute_sri",
-+    "compute_nds",
-+    "compute_vsd",
-+    "compute_mce",
-+    "generate_monitoring_metrics",
- ]
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
- 
+"""Modules for analyzing simulation state and results."""
 
+from .analyzer import AgentStateAnalyzer
+from .exporter import ChronicleExporter
+from .tda import PersistentHomologyTracker
+from .visualization import (
+    plot_persistence_diagram,
+    plot_persistence_barcode,
+    plot_metric_comparison,
+)
+from .clustering import cluster_archetypes
+from ..metrics.monitoring import (
+    compute_sri,
+    compute_nds,
+    compute_vsd,
+    compute_mce,
+    generate_monitoring_metrics,
+)
 
-
-
-
-
-
-
-
-
-
-
+__all__ = [
+    "AgentStateAnalyzer",
+    "ChronicleExporter",
+    "PersistentHomologyTracker",
+    "plot_persistence_diagram",
+    "plot_persistence_barcode",
+    "plot_metric_comparison",
+    "cluster_archetypes",
+    "compute_sri",
+    "compute_nds",
+    "compute_vsd",
+    "compute_mce",
+    "generate_monitoring_metrics",
+]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import sys
+from pathlib import Path
+
+# Add project src directory to sys.path for tests without requiring installation
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SRC_DIR = ROOT_DIR / "src"
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))


### PR DESCRIPTION
## Summary
- fix `agisa_sac.analysis.__init__` by removing stray diff markers
- add `tests/conftest.py` so pytest finds the `agisa_sac` package

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_685e36de406c8331bf9c16c1f665716e