### PR TITLE
Add GCP scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,16 @@ This platform is a **sandbox for ethics-first experimentation**, simulating:
 
 ## 🛠 Infrastructure Roadmap
 
-- ✅ Current: Local/Colab prototype with 10–50 agents  
-- 🔄 Next: Migration to GCP with Kubernetes for full-scale orchestration  
+- ✅ Current: Local/Colab prototype with 10–50 agents
+- 🔄 Next: Migration to GCP with Kubernetes for full-scale orchestration
 - 🔜 Future: Vertex AI integration, automated memory decay tuning, and behavioral lineage visualization
+
+### GCP Deployment
+
+Infrastructure scripts for Google Cloud are located under `infra/gcp`. A helper
+script `deploy_vm.sh` provisions GPU-enabled Compute Engine instances and basic
+Kubernetes manifests are provided in `infra/gcp/k8s`. The `sim_runner.py` CLI
+can run simulations with the `--use-gpu` flag when a GPU is available.
 
 ---
 

--- a/containers/chaos_gremlin/Dockerfile
+++ b/containers/chaos_gremlin/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY .. /app
+CMD ["python", "-m", "agisa_sac.utils.chaos_gremlin"]

--- a/containers/enhanced_agent/Dockerfile
+++ b/containers/enhanced_agent/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY .. /app
+RUN pip install --no-cache-dir -e .
+CMD ["python", "sim_runner.py", "config.json"]

--- a/containers/resonance_chronicler/Dockerfile
+++ b/containers/resonance_chronicler/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY .. /app
+CMD ["python", "-m", "agisa_sac.chronicler"]

--- a/containers/satori_detector/Dockerfile
+++ b/containers/satori_detector/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY .. /app
+CMD ["python", "-m", "agisa_sac.utils.satori_detector"]

--- a/containers/tal/Dockerfile
+++ b/containers/tal/Dockerfile
@@ -1,0 +1,4 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY .. /app
+CMD ["python", "-m", "agisa_sac.utils.tal"]

--- a/docs/gcp_setup.md
+++ b/docs/gcp_setup.md
@@ -1,0 +1,19 @@
+# GCP Setup
+
+This document outlines basic steps to run AGI-SAC in Google Cloud.
+
+1. **Provision a GPU VM**
+   ```bash
+   infra/gcp/deploy_vm.sh my-sim us-central1-a nvidia-tesla-t4 1
+   ```
+2. **Build Docker image**
+   ```bash
+   docker build -t gcr.io/PROJECT_ID/agisac:latest -f containers/enhanced_agent/Dockerfile .
+   ```
+3. **Deploy to GKE**
+   ```bash
+   kubectl apply -f infra/gcp/k8s/deployment.yaml
+   kubectl apply -f infra/gcp/k8s/service.yaml
+   ```
+
+Functions for scroll export and time pulses are located in the `functions` directory.

--- a/functions/scroll_export/main.py
+++ b/functions/scroll_export/main.py
@@ -1,0 +1,20 @@
+"""Cloud Function to export scroll data to Cloud Storage."""
+from __future__ import annotations
+
+from google.cloud import storage
+import base64
+import json
+
+
+def export_scroll(event, context):
+    data = base64.b64decode(event['data']).decode('utf-8')
+    payload = json.loads(data)
+    bucket_name = payload['bucket']
+    filename = payload['filename']
+    content = payload['content']
+
+    client = storage.Client()
+    bucket = client.bucket(bucket_name)
+    blob = bucket.blob(filename)
+    blob.upload_from_string(content)
+    return f"Uploaded {filename} to {bucket_name}"

--- a/functions/time_pulse/main.py
+++ b/functions/time_pulse/main.py
@@ -1,0 +1,16 @@
+"""Pub/Sub triggered function to emit synthetic time pulses."""
+from __future__ import annotations
+
+import base64
+import json
+from google.cloud import pubsub_v1
+
+publisher = pubsub_v1.PublisherClient()
+TOPIC = "synthetic-time"
+
+
+def tick(event, context):
+    count = int(base64.b64decode(event['data']).decode('utf-8'))
+    payload = json.dumps({"pulse": count}).encode('utf-8')
+    topic_path = publisher.topic_path(context.project, TOPIC)
+    publisher.publish(topic_path, payload)

--- a/infra/gcp/bigquery_schema.sql
+++ b/infra/gcp/bigquery_schema.sql
@@ -1,0 +1,22 @@
+-- BigQuery schema for AGI-SAC simulation data
+CREATE TABLE IF NOT EXISTS `simulation.memory_scrolls` (
+    agent_id STRING,
+    epoch INT64,
+    timestamp TIMESTAMP,
+    scroll JSON,
+    PRIMARY KEY(agent_id, epoch)
+);
+
+CREATE TABLE IF NOT EXISTS `simulation.agent_phases` (
+    agent_id STRING,
+    phase STRING,
+    started TIMESTAMP,
+    ended TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS `simulation.homology_topologies` (
+    run_id STRING,
+    dimension INT64,
+    birth FLOAT64,
+    death FLOAT64
+);

--- a/infra/gcp/deploy_vm.sh
+++ b/infra/gcp/deploy_vm.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Simple script to provision a GPU VM on Google Compute Engine
+# Usage: ./deploy_vm.sh <vm-name> <zone> <gpu-type> <gpu-count>
+set -euo pipefail
+
+VM_NAME=${1:-agisac-sim}
+ZONE=${2:-us-central1-a}
+GPU_TYPE=${3:-nvidia-tesla-t4}
+GPU_COUNT=${4:-1}
+
+# Machine type defaults to a4-highgpu-1g for A100 or n1-standard-4 for T4
+if [[ $GPU_TYPE == nvidia-a100* ]]; then
+    MACHINE_TYPE="a2-highgpu-1g"
+else
+    MACHINE_TYPE="n1-standard-4"
+fi
+
+gcloud compute instances create "$VM_NAME" \
+    --zone "$ZONE" \
+    --machine-type "$MACHINE_TYPE" \
+    --accelerator type=$GPU_TYPE,count=$GPU_COUNT \
+    --boot-disk-size 200GB \
+    --maintenance-policy TERMINATE \
+    --restart-on-failure
+
+# Print connection info
+echo "VM $VM_NAME created in $ZONE with $GPU_COUNT $GPU_TYPE GPU(s)."

--- a/infra/gcp/k8s/deployment.yaml
+++ b/infra/gcp/k8s/deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: agisac-simulation
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: agisac
+  template:
+    metadata:
+      labels:
+        app: agisac
+    spec:
+      containers:
+      - name: orchestrator
+        image: gcr.io/PROJECT_ID/agisac:latest
+        command: ["python", "sim_runner.py", "config.json"]
+        resources:
+          limits:
+            nvidia.com/gpu: 1

--- a/infra/gcp/k8s/service.yaml
+++ b/infra/gcp/k8s/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: agisac-svc
+spec:
+  type: ClusterIP
+  selector:
+    app: agisac
+  ports:
+    - port: 80
+      targetPort: 8080

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,3 +19,9 @@ build-backend = "setuptools.build_meta"
 
 [project.optional-dependencies]
 gpu = ["cupy"]
+gcp = [
+    "google-cloud-storage",
+    "google-cloud-bigquery",
+    "google-cloud-aiplatform",
+    "google-cloud-pubsub"
+]

--- a/sim_runner.py
+++ b/sim_runner.py
@@ -1,0 +1,25 @@
+"""Command line interface for running AGI-SAC simulations on GCP or locally."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import json
+
+from agisa_sac import SimulationOrchestrator
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run AGI-SAC simulation")
+    parser.add_argument("config", type=Path, help="Path to JSON config file")
+    parser.add_argument("--use-gpu", action="store_true", help="Enable GPU acceleration")
+    args = parser.parse_args()
+
+    config = json.loads(Path(args.config).read_text())
+    config["use_gpu"] = args.use_gpu
+    orchestrator = SimulationOrchestrator(config)
+    orchestrator.run_simulation()
+    print(orchestrator.analyzer.summarize())
+
+
+if __name__ == "__main__":
+    main()

--- a/src/agisa_sac/__init__.py
+++ b/src/agisa_sac/__init__.py
@@ -25,6 +25,7 @@ try:
         plot_persistence_barcode,
         plot_metric_comparison,
     )
+    from .gcp import VertexAgent
     from .analysis.clustering import cluster_archetypes
     from .metrics.monitoring import (
         compute_sri,
@@ -66,6 +67,7 @@ __all__ = [
     "compute_vsd",
     "compute_mce",
     "generate_monitoring_metrics",
+    "VertexAgent",
 ]
 
 import logging

--- a/src/agisa_sac/chronicler.py
+++ b/src/agisa_sac/chronicler.py
@@ -37,6 +37,19 @@ class ResonanceChronicler:
         """Serialize all stored lineages to a dictionary."""
         return {aid: [asdict(e) for e in entries] for aid, entries in self.lineages.items()}
 
+    def export_to_bigquery(self, table_id: str) -> None:
+        """Export stored lineages to a BigQuery table."""
+        from .gcp.bigquery_client import insert_rows
+
+        rows = []
+        for aid, entries in self.lineages.items():
+            for e in entries:
+                row = asdict(e)
+                row["agent_id"] = aid
+                rows.append(row)
+        if rows:
+            insert_rows(table_id, rows)
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> 'ResonanceChronicler':
         inst = cls()

--- a/src/agisa_sac/components/memory.py
+++ b/src/agisa_sac/components/memory.py
@@ -252,6 +252,16 @@ class MemoryContinuumLayer:
                  "use_semantic_config": self.use_semantic, "last_update": self.last_update,
                  "memories": {mid: mem.to_dict(include_embedding=include_embeddings) for mid, mem in self.memories.items()} }
 
+    def backup_to_gcs(self, bucket: str, path: str) -> None:
+        """Serialize and upload memory state to Google Cloud Storage."""
+        from ..gcp.gcs_io import upload_file
+        import json, tempfile
+
+        with tempfile.NamedTemporaryFile("w", delete=False) as tmp:
+            json.dump(self.to_dict(include_embeddings=True), tmp)
+            tmp_path = tmp.name
+        upload_file(bucket, tmp_path, path)
+
     @classmethod
     def from_dict(cls, data: Dict[str, Any], message_bus: Optional['MessageBus'] = None) -> 'MemoryContinuumLayer':
         loaded_version = data.get("version"); agent_id = data['agent_id']

--- a/src/agisa_sac/gcp/__init__.py
+++ b/src/agisa_sac/gcp/__init__.py
@@ -1,0 +1,7 @@
+"""Google Cloud Platform integration utilities for AGI-SAC."""
+
+from .gcs_io import upload_file, download_file
+from .bigquery_client import insert_rows, query
+from .vertex_agent import VertexAgent
+
+__all__ = ["upload_file", "download_file", "insert_rows", "query", "VertexAgent"]

--- a/src/agisa_sac/gcp/bigquery_client.py
+++ b/src/agisa_sac/gcp/bigquery_client.py
@@ -1,0 +1,20 @@
+"""Simplified BigQuery client wrapper for AGI-SAC exports."""
+from __future__ import annotations
+
+from google.cloud import bigquery
+from typing import Any, Iterable
+
+
+def insert_rows(table_id: str, rows: Iterable[dict]) -> None:
+    """Insert rows into a BigQuery table."""
+    client = bigquery.Client()
+    errors = client.insert_rows_json(table_id, list(rows))
+    if errors:
+        raise RuntimeError(f"BigQuery insert errors: {errors}")
+
+
+def query(sql: str) -> list[dict[str, Any]]:
+    """Run a query and return the results as dictionaries."""
+    client = bigquery.Client()
+    query_job = client.query(sql)
+    return [dict(row) for row in query_job.result()]

--- a/src/agisa_sac/gcp/gcs_io.py
+++ b/src/agisa_sac/gcp/gcs_io.py
@@ -1,0 +1,22 @@
+"""Utility functions for Google Cloud Storage interactions."""
+from __future__ import annotations
+
+from google.cloud import storage
+from pathlib import Path
+from typing import Union
+
+
+def upload_file(bucket_name: str, source: Union[str, Path], destination_blob: str) -> None:
+    """Upload a file to a bucket."""
+    client = storage.Client()
+    bucket = client.bucket(bucket_name)
+    blob = bucket.blob(destination_blob)
+    blob.upload_from_filename(str(source))
+
+
+def download_file(bucket_name: str, blob_name: str, destination: Union[str, Path]) -> None:
+    """Download a blob from a bucket."""
+    client = storage.Client()
+    bucket = client.bucket(bucket_name)
+    blob = bucket.blob(blob_name)
+    blob.download_to_filename(str(destination))

--- a/src/agisa_sac/gcp/vertex_agent.py
+++ b/src/agisa_sac/gcp/vertex_agent.py
@@ -1,0 +1,20 @@
+"""Wrapper class to interact with Vertex AI models."""
+from __future__ import annotations
+
+from google.cloud import aiplatform
+from typing import Any
+
+
+aiplatform.init()
+
+
+class VertexAgent:
+    """Simple proxy to call Vertex AI text models."""
+
+    def __init__(self, model: str = "text-bison") -> None:
+        self.model = model
+        self.endpoint = aiplatform.TextGenerationModel.from_pretrained(model)
+
+    def generate(self, prompt: str, **params: Any) -> str:
+        response = self.endpoint.predict(prompt, **params)
+        return response.text

--- a/tests/test_gcp_imports.py
+++ b/tests/test_gcp_imports.py
@@ -1,0 +1,10 @@
+from importlib import import_module
+
+def test_gcp_modules_importable():
+    modules = [
+        'agisa_sac.gcp.gcs_io',
+        'agisa_sac.gcp.bigquery_client',
+        'agisa_sac.gcp.vertex_agent'
+    ]
+    for mod in modules:
+        import_module(mod)


### PR DESCRIPTION
## Summary
- add deployment and Kubernetes manifests under `infra/gcp`
- create container Dockerfiles for core subsystems
- implement Vertex AI, BigQuery, and GCS helper modules
- expose BigQuery export and GCS backup hooks
- provide CLI `sim_runner.py` with GPU flag
- document GCP setup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685e3a3b28c88331aaae9d0bd5f6cd90