### PR TITLE
Fix Tuple type hint import

### DIFF
--- a/src/agisa_sac/analysis/tda.py
+++ b/src/agisa_sac/analysis/tda.py
@@ -1,6 +1,6 @@
 import numpy as np
 import warnings
-from typing import Dict, List, Optional, Any
+from typing import Dict, List, Optional, Any, Tuple
 
 # Import framework version
 try:


### PR DESCRIPTION
## Summary
- add missing `Tuple` import in tda module
- install httpx for FastAPI test client

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cloud')*

------
https://chatgpt.com/codex/tasks/task_e_687891b86a64833193e3f1c42152ecbb