### PR TITLE
Clean CI and add GCP badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,12 +68,6 @@ jobs:
             test-results.xml
             coverage.xml
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          files: coverage.xml
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Authenticate to Google Cloud
         if: github.ref == 'refs/heads/main' && matrix.python-version == '3.11'
@@ -90,37 +84,7 @@ jobs:
         if: github.ref == 'refs/heads/main' && matrix.python-version == '3.11'
         run: gcloud run services list --project ${{ secrets.GCP_PROJECT_ID }}
 
-      - name: Slack failure notification
-        if: failure() && secrets.SLACK_WEBHOOK_URL != ''
-        uses: slackapi/slack-github-action@v1.26.0
-        with:
-          payload: |
-            {
-              "text": "CI Job Failed: `${{ github.workflow }}`",
-              "blocks": [
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "CI Job Failed: `${{ github.workflow }}`"
-                  }
-                },
-                {
-                  "type": "section",
-                  "fields": [
-                    { "type": "mrkdwn", "text": "*Repository:*\n`${{ github.repository }}`" },
-                    { "type": "mrkdwn", "text": "*Ref:*\n`${{ github.ref }}`" },
-                    { "type": "mrkdwn", "text": "*Job Status:*\n${{ job.status }}" },
-                    { "type": "mrkdwn", "text": "*Triggered by:*\n${{ github.actor }}" }
-                  ]
-                },
-                {
-                  "type": "actions",
-                  "elements": [
-                    { "type": "button", "text": { "type": "plain_text", "text": "View Failed Run" }, "url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" }
-                  ]
-                }
-              ]
-            }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      - name: GKE deploy preview
+        if: github.ref == 'refs/heads/main' && matrix.python-version == '3.11'
+        run: kubectl apply -f infra/gcp/k8s --dry-run=client
+

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ For a comprehensive overview of the system’s architecture, philosophy, and gov
 [![View White Paper](https://img.shields.io/badge/Mindlink_White_Paper-View-blue)](docs/Mindlink_WhitePaper_v1.0.pdf)
 
 For comprehensive documentation, see [docs/README_FULL_AGI_SAC_v1.0.3.md](docs/README_FULL_AGI_SAC_v1.0.3.md).
+
+[![Deployed to GCP](https://img.shields.io/badge/deployed-GCP-brightgreen)](docs/gcp_setup.md)
 ---
 
 ## 🚧 Current Capabilities


### PR DESCRIPTION
## Summary
- remove Codecov and Slack steps from CI
- add a dry-run deploy preview step for GKE
- show deployment badge in README

## Testing
- `pytest -q` *(fails: ContinuityBridgeProtocol has no attribute 'quarantined_fragments', ModuleNotFoundError: No module named 'google')*

------
https://chatgpt.com/codex/tasks/task_e_687df27a699483319fa47eac4be14033