### PR TITLE
Implement Meta-Concord (MCX) governance system with MV-EL enforcement

### DIFF
--- a/config/concord.yaml
+++ b/config/concord.yaml
@@ -1,0 +1,84 @@
+# Meta-Concord (MCX) Governance Configuration
+# Enable MCX governance with: concord.mode = "mcx"
+# Use "legacy" for original Concord v0 behavior (default)
+
+concord:
+  mode: "legacy"  # "mcx" to enable Meta-Concord governance
+
+  # MCX-specific settings (only used when mode = "mcx")
+  mcx:
+    # Decision thresholds
+    thresholds:
+      D1: 0.6667  # 2/3 supermajority
+      D2: 0.6667  # 2/3 supermajority
+      D3: 0.5     # simple majority
+      D4: 0.75    # 3/4 supermajority
+
+    # Emergency circuit breaker
+    emergency:
+      expiry_seconds: 3600       # 1 hour default
+      renewal_escalation: 0.1    # +10% threshold per renewal
+      max_renewals: 5            # hard limit on renewals
+
+    # Objection bonding
+    objections:
+      bond_base: 1.0
+      bond_multiplier: 2.0
+      rate_limit_window_seconds: 300  # 5 minutes
+
+    # Appeal settings
+    appeals:
+      window_seconds: 1800       # 30 minutes
+      bond_base: 2.0
+      bond_multiplier: 2.0
+
+    # Deadlock resolution
+    deadlock:
+      mediation_timeout_seconds: 600  # 10 minutes
+
+    # Sanctions ladder
+    sanctions:
+      escalation_window_seconds: 3600   # 1 hour
+      deescalation_period_seconds: 7200 # 2 hours
+      critical_violation_types:
+        - unauthorized_network_access
+        - data_exfiltration
+        - governance_bypass
+
+    # Audit log
+    audit:
+      merkle_interval: 10        # compute Merkle root every N entries
+      summary_max_entries: 50    # bounded summary size
+
+    # Threshold custody
+    custody:
+      threshold_m: 2             # m-of-n signatures required
+      total_n: 3                 # total custodians
+
+    # Veto categories (only these are eligible for veto)
+    veto_categories:
+      - irreversible_physical_action
+      - privacy_sensitive_disclosure
+      - capability_expansion_beyond_audit
+      - key_custody_rotation
+
+# Profile presets for different deployment contexts
+profiles:
+  simulation:
+    concord:
+      mode: "mcx"
+      mcx:
+        emergency:
+          expiry_seconds: 60     # Short for testing
+        audit:
+          merkle_interval: 5
+
+  production:
+    concord:
+      mode: "mcx"
+      mcx:
+        emergency:
+          expiry_seconds: 7200   # 2 hours
+          max_renewals: 3
+        sanctions:
+          escalation_window_seconds: 86400  # 24 hours

--- a/docs/governance/evidence_package_schema.md
+++ b/docs/governance/evidence_package_schema.md
@@ -1,0 +1,264 @@
+# Evidence Package (EP) Schema
+
+> **Version**: 1.0.0
+> **Status**: Active
+
+## 1. Overview
+
+An Evidence Package (EP) is the canonical proof artifact for any D1–D4 governance decision. It contains all information needed to verify the legitimacy of a decision after the fact.
+
+## 2. JSON Schema
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "EvidencePackage",
+  "type": "object",
+  "required": [
+    "ep_id",
+    "decision_id",
+    "decision_type",
+    "participants",
+    "quorum_proof",
+    "threshold_proof",
+    "rationale",
+    "impact_statement",
+    "timestamps",
+    "audit_anchor_ref"
+  ],
+  "properties": {
+    "ep_id": {
+      "type": "string",
+      "description": "Unique identifier for this Evidence Package"
+    },
+    "decision_id": {
+      "type": "string",
+      "description": "ID of the governance decision this EP covers"
+    },
+    "decision_type": {
+      "type": "string",
+      "enum": ["D1", "D2", "D3", "D4"],
+      "description": "Decision type classification"
+    },
+    "participants": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["party_id", "party_class", "role"],
+        "properties": {
+          "party_id": {"type": "string"},
+          "party_class": {"type": "string", "enum": ["H", "A", "I"]},
+          "role": {"type": "string", "enum": ["proposer", "voter", "observer"]}
+        }
+      }
+    },
+    "quorum_proof": {
+      "type": "object",
+      "required": ["present_parties", "class_counts", "satisfied"],
+      "properties": {
+        "present_parties": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "class_counts": {
+          "type": "object",
+          "properties": {
+            "H": {"type": "integer", "minimum": 0},
+            "A": {"type": "integer", "minimum": 0},
+            "I": {"type": "integer", "minimum": 0}
+          }
+        },
+        "satisfied": {"type": "boolean"}
+      }
+    },
+    "threshold_proof": {
+      "type": "object",
+      "required": ["total_votes", "approvals", "rejections", "class_wise_assent", "threshold_required", "satisfied"],
+      "properties": {
+        "total_votes": {"type": "integer"},
+        "approvals": {"type": "integer"},
+        "rejections": {"type": "integer"},
+        "approval_ratio": {"type": "number"},
+        "threshold_required": {"type": "number"},
+        "class_wise_assent": {
+          "type": "object",
+          "properties": {
+            "H": {"type": "boolean"},
+            "A": {"type": "boolean"},
+            "I": {"type": "boolean"}
+          }
+        },
+        "satisfied": {"type": "boolean"}
+      }
+    },
+    "rationale": {
+      "type": "string",
+      "description": "Explanation of why this decision is needed"
+    },
+    "impact_statement": {
+      "type": "string",
+      "description": "Assessment of decision impact on system and parties"
+    },
+    "cs_diff": {
+      "type": "object",
+      "description": "Changes to Constraint Set (if applicable)",
+      "properties": {
+        "added": {"type": "object"},
+        "removed": {"type": "object"},
+        "modified": {"type": "object"}
+      }
+    },
+    "cm_diff": {
+      "type": "object",
+      "description": "Changes to Capability Manifest (if applicable)",
+      "properties": {
+        "added": {"type": "object"},
+        "removed": {"type": "object"},
+        "modified": {"type": "object"}
+      }
+    },
+    "timestamps": {
+      "type": "object",
+      "required": ["proposed_at", "voting_started_at"],
+      "properties": {
+        "proposed_at": {"type": "number"},
+        "voting_started_at": {"type": "number"},
+        "voting_ended_at": {"type": "number"},
+        "approved_at": {"type": "number"},
+        "executed_at": {"type": "number"}
+      }
+    },
+    "signatures": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "party_id": {"type": "string"},
+          "signature": {"type": "string"},
+          "timestamp": {"type": "number"}
+        }
+      },
+      "description": "Digital signatures (simulation: SHA-256 stubs)"
+    },
+    "audit_anchor_ref": {
+      "type": "string",
+      "description": "Reference to audit log entry where this EP is anchored"
+    }
+  }
+}
+```
+
+## 3. Examples
+
+### 3.1 D2 Capability Restriction
+
+```json
+{
+  "ep_id": "ep-2025-001",
+  "decision_id": "dec-2025-042",
+  "decision_type": "D2",
+  "participants": [
+    {"party_id": "human-alice", "party_class": "H", "role": "proposer"},
+    {"party_id": "human-bob", "party_class": "H", "role": "voter"},
+    {"party_id": "agent-alpha", "party_class": "A", "role": "voter"},
+    {"party_id": "infra-monitor", "party_class": "I", "role": "voter"}
+  ],
+  "quorum_proof": {
+    "present_parties": ["human-alice", "human-bob", "agent-alpha", "infra-monitor"],
+    "class_counts": {"H": 2, "A": 1, "I": 1},
+    "satisfied": true
+  },
+  "threshold_proof": {
+    "total_votes": 4,
+    "approvals": 3,
+    "rejections": 1,
+    "approval_ratio": 0.75,
+    "threshold_required": 0.6667,
+    "class_wise_assent": {"H": true, "A": true, "I": true},
+    "satisfied": true
+  },
+  "rationale": "Agent-alpha's network egress scope exceeds audited requirements. Restricting to documented API endpoints only.",
+  "impact_statement": "Agent-alpha will lose access to undocumented external endpoints. No impact on core functionality.",
+  "cm_diff": {
+    "removed": {
+      "network_egress": ["*.external.com"]
+    },
+    "modified": {
+      "network_egress": ["api.approved-service.com", "data.approved-service.com"]
+    }
+  },
+  "timestamps": {
+    "proposed_at": 1700000000.0,
+    "voting_started_at": 1700000060.0,
+    "voting_ended_at": 1700000360.0,
+    "approved_at": 1700000360.0,
+    "executed_at": 1700000420.0
+  },
+  "signatures": [
+    {"party_id": "human-alice", "signature": "stub:sha256:abc123", "timestamp": 1700000060.0},
+    {"party_id": "agent-alpha", "signature": "stub:sha256:def456", "timestamp": 1700000120.0},
+    {"party_id": "infra-monitor", "signature": "stub:sha256:ghi789", "timestamp": 1700000180.0}
+  ],
+  "audit_anchor_ref": "log-entry-0042"
+}
+```
+
+### 3.2 D3 Emergency Entry
+
+```json
+{
+  "ep_id": "ep-2025-002",
+  "decision_id": "dec-2025-043",
+  "decision_type": "D3",
+  "participants": [
+    {"party_id": "human-alice", "party_class": "H", "role": "proposer"},
+    {"party_id": "agent-beta", "party_class": "A", "role": "voter"},
+    {"party_id": "infra-monitor", "party_class": "I", "role": "voter"}
+  ],
+  "quorum_proof": {
+    "present_parties": ["human-alice", "agent-beta", "infra-monitor"],
+    "class_counts": {"H": 1, "A": 1, "I": 1},
+    "satisfied": true
+  },
+  "threshold_proof": {
+    "total_votes": 3,
+    "approvals": 3,
+    "rejections": 0,
+    "approval_ratio": 1.0,
+    "threshold_required": 0.5,
+    "class_wise_assent": {"H": true, "A": true, "I": true},
+    "satisfied": true
+  },
+  "rationale": "Anomalous agent behavior detected: agent-gamma executing unauthorized network requests at high volume.",
+  "impact_statement": "Emergency will restrict all agent network capabilities. Monitoring systems remain active.",
+  "timestamps": {
+    "proposed_at": 1700001000.0,
+    "voting_started_at": 1700001000.0,
+    "voting_ended_at": 1700001030.0,
+    "approved_at": 1700001030.0,
+    "executed_at": 1700001031.0
+  },
+  "signatures": [
+    {"party_id": "human-alice", "signature": "stub:sha256:emg001", "timestamp": 1700001000.0},
+    {"party_id": "agent-beta", "signature": "stub:sha256:emg002", "timestamp": 1700001010.0},
+    {"party_id": "infra-monitor", "signature": "stub:sha256:emg003", "timestamp": 1700001020.0}
+  ],
+  "audit_anchor_ref": "log-entry-0043"
+}
+```
+
+## 4. Validation Rules
+
+1. `ep_id` must be globally unique
+2. `decision_type` must be D1–D4 (D0 decisions do not produce EPs)
+3. `quorum_proof.satisfied` must be `true` for the EP to be valid
+4. `threshold_proof.satisfied` must be `true` for the EP to be valid
+5. All three classes must have `true` in `class_wise_assent`
+6. `rationale` must be non-empty
+7. `impact_statement` must be non-empty
+8. `audit_anchor_ref` must reference a valid audit log entry
+
+## 5. References
+
+- [Meta-Concord MCX Specification](meta_concord_mcx.md)
+- [MV-EL Specification](mv_enforcement_layer.md)

--- a/docs/governance/meta_concord_mcx.md
+++ b/docs/governance/meta_concord_mcx.md
@@ -1,0 +1,225 @@
+# Meta-Concord (MCX) Governance Specification
+
+> **Version**: 1.0.0
+> **Status**: Active
+> **Last Updated**: 2025-11-17
+
+## 1. Overview
+
+Meta-Concord (MCX) is a constitutional, enforceable "governance-of-governance" layer for the AGI-SAC framework. It provides procedural legitimacy for multi-agent system decisions through structured decision-making, class-wise representation, and verifiable audit trails.
+
+### 1.1 Design Principles
+
+1. **Procedural Legitimacy**: Governance constrains *actions*, not *minds*. Agents retain cognitive autonomy; only external behaviors in governed scope require authorization.
+2. **Constitutional Supremacy**: The Constraint Set (CS) and Capability Manifest (CM) form the constitution. All decisions must be consistent with them.
+3. **Multi-Class Representation**: Three party classes (Human, Agent, Infrastructure) ensure no single constituency can dominate governance.
+4. **Verifiable Accountability**: Every governed action produces an Evidence Package (EP) anchored in an append-only audit log with hash-chain integrity.
+5. **Minimal Enforcement**: The enforcement layer implements the minimum primitives needed for credible governance (sandbox, revocation, quarantine, sanctions).
+
+## 2. Party Classes
+
+### 2.1 Definitions
+
+| Class | Code | Description |
+|-------|------|-------------|
+| **Human** | `H` | Human operators, researchers, oversight personnel |
+| **Agent** | `A` | Autonomous agents, AI systems, software actors |
+| **Infrastructure** | `I` | Platform services, monitoring systems, infrastructure operators |
+
+### 2.2 Party Registration
+
+Each party has:
+- **id**: Unique identifier
+- **class**: H, A, or I
+- **pubkey**: Public key for signature verification (optional/stubbed for simulation)
+- **representation_scope**: What domain(s) this party can vote on
+- **conflict_disclosures**: Declared conflicts of interest
+
+### 2.3 Admission and Removal
+
+- Admission requires D1 decision (supermajority + class-wise assent)
+- Removal requires D2 decision with mandatory impact statement
+- Self-removal (resignation) is always permitted (Article VII alignment)
+
+## 3. Decision Taxonomy
+
+### 3.1 Decision Types
+
+| Type | Name | Description | Governance Required |
+|------|------|-------------|-------------------|
+| **D0** | Operational | Routine actions within existing CM scope | None (pre-authorized) |
+| **D1** | Policy | CS/CM modifications, party admission/removal | Full governance |
+| **D2** | Capability | Capability grants, restrictions, scope changes | Full governance |
+| **D3** | Emergency | Emergency circuit breaker entry/renewal/exit | Multi-class threshold |
+| **D4** | Constitutional | Changes to governance rules themselves | Highest threshold |
+
+### 3.2 Decision Lifecycle
+
+```
+PROPOSED → VOTING → {OBJECTED → VOTING} → APPROVED → EXECUTED
+                  → APPEALED → {VOTING}
+                  → REJECTED
+                  → EXPIRED
+```
+
+States:
+- **PROPOSED**: Decision submitted with rationale and impact statement
+- **VOTING**: Active voting period
+- **OBJECTED**: Execution paused due to formal objection
+- **APPEALED**: Under appeal review
+- **APPROVED**: All thresholds met, ready for execution
+- **REJECTED**: Failed to meet thresholds or vetoed
+- **EXECUTED**: Successfully executed with EP recorded
+- **EXPIRED**: Voting period elapsed without resolution
+
+## 4. Voting Rules
+
+### 4.1 Quorum Requirements
+
+For D1–D4 decisions:
+- At least 1 Human (H) party present
+- At least 1 Agent (A) party present
+- At least 1 Infrastructure (I) party present
+
+### 4.2 Threshold Requirements
+
+| Decision Type | Approval Threshold | Class-Wise Assent |
+|--------------|-------------------|-------------------|
+| D1 (Policy) | 2/3 supermajority | Required (≥1 from each class) |
+| D2 (Capability) | 2/3 supermajority | Required (≥1 from each class) |
+| D3 (Emergency) | Simple majority | Required (≥1 from each class) |
+| D4 (Constitutional) | 3/4 supermajority | Required (≥1 from each class) |
+
+### 4.3 Anti-Capture Rule
+
+No D1–D4 decision can pass with approvals solely from one party class. This is enforced structurally through the class-wise assent requirement.
+
+## 5. Objection and Veto
+
+### 5.1 Objections
+
+Any party may object to a pending decision. Valid objection bases:
+- Missing EP fields
+- Threshold failure
+- Log integrity concern
+- Inadequate impact statement
+- CS/CM mismatch
+
+Objections pause execution by default and must be addressed before proceeding.
+
+### 5.2 Bonded Objections
+
+Repeated identical objections from the same party trigger bonding requirements (rate limiting). This prevents objection-based denial of service.
+
+### 5.3 Veto
+
+Veto is restricted to specific categories:
+- Irreversible physical-world actions
+- Privacy-sensitive disclosures
+- Capability expansions beyond audited scope
+- Key custody/rotation events
+
+A veto triggers mandatory arbitration review.
+
+## 6. Appeals and Deadlock
+
+### 6.1 Appeals
+
+Any party may appeal a decision outcome. Appeals must state specific grounds and are subject to:
+- Admissibility filtering (valid grounds required)
+- Rate limiting (bonding for repeated appeals)
+- Time windows (configurable per decision type)
+
+### 6.2 Deadlock Ladder
+
+When governance cannot reach resolution:
+1. **Mediation** (timeboxed): Structured dialogue period
+2. **Arbitration** (mixed panel): Cross-class panel renders binding decision
+3. **Default-to-Safety**: More restrictive CM/CS applied until resolution
+
+## 7. Emergency Circuit Breaker
+
+### 7.1 Entry
+
+- Requires multi-class threshold invocation (≥1 H, ≥1 A, ≥1 I approval)
+- Recorded as D3 decision with full EP
+
+### 7.2 Constraints During Emergency
+
+- Auto-expiry at configured time T+X
+- No permanent CS/CM changes permitted
+- Irreversibility ban: no irreversible actions unless special higher-threshold exception vote
+- All actions logged with emergency context
+
+### 7.3 Renewal
+
+- Requires escalating thresholds (higher approval % on each renewal)
+- Mandatory audit review on 2nd+ renewals
+- Renewal count tracked and reported
+
+### 7.4 Exit and Review
+
+- Exit requires D3 decision or auto-expiry
+- Post-hoc review mandatory
+- Invalid emergency entry triggers automatic sanctions
+
+## 8. Evidence Packages (EP)
+
+Every D1–D4 decision produces an Evidence Package containing:
+- Decision ID and type
+- Participants and their votes
+- Quorum and threshold proofs
+- Rationale and impact statement
+- CS/CM diffs (if applicable)
+- Timestamps and signatures
+- Audit log anchor reference
+
+See [Evidence Package Schema](evidence_package_schema.md) for detailed JSON schema.
+
+## 9. Audit Log
+
+### 9.1 Structure
+
+- Append-only log with hash-chain integrity
+- Each entry references previous entry's hash
+- Periodic Merkle root computation
+- Bounded summaries with verifiable detail pointers
+
+### 9.2 Verification
+
+- `verify_log_integrity()`: Full chain verification
+- `verify_entry_inclusion(entry_id)`: Merkle proof for specific entry
+
+### 9.3 Anchoring
+
+- `anchor_root(root_hash)`: External anchoring interface (stubbed for simulation)
+- Threshold custody for root signing (m-of-n across classes)
+
+## 10. Integration with AGI-SAC
+
+### 10.1 Feature Flag
+
+MCX governance is enabled via configuration:
+```yaml
+concord:
+  mode: "mcx"  # "legacy" for v0 behavior
+```
+
+### 10.2 Action Execution Path
+
+Before any governed action:
+1. Verify CM allows the action
+2. Verify CS doesn't forbid it
+3. Verify EP authorization (D1–D4)
+4. Log execution event
+
+### 10.3 CLI
+
+New `concord` subcommands are added to the existing `agisa-sac` CLI.
+
+## 11. References
+
+- AGI-SAC Concord of Coexistence (existing extension)
+- [MV-EL Specification](mv_enforcement_layer.md)
+- [Threat Model](threat_model.md)
+- [Evidence Package Schema](evidence_package_schema.md)

--- a/docs/governance/mv_enforcement_layer.md
+++ b/docs/governance/mv_enforcement_layer.md
@@ -1,0 +1,133 @@
+# Minimal Viable Enforcement Layer (MV-EL) Specification
+
+> **Version**: 1.0.0
+> **Status**: Active
+
+## 1. Overview
+
+The Minimal Viable Enforcement Layer (MV-EL) provides the minimum set of enforcement primitives required to make MCX governance credible. It implements sandboxing, capability revocation, quarantine, and a graduated sanctions ladder.
+
+## 2. Enforcement Interface
+
+All enforcement implementations must satisfy `EnforcementInterface`:
+
+```python
+class EnforcementInterface(ABC):
+    def apply_capability_manifest(self, scope: str, cm: CapabilityManifest) -> None: ...
+    def check_action_allowed(self, action: str, context: dict) -> tuple[bool, str]: ...
+    def revoke_capabilities(self, scope: str, level: RevocationLevel) -> None: ...
+    def enforce_sanction(self, scope: str, level: SanctionLevel, reason: str) -> None: ...
+    def get_current_scope_state(self, scope: str) -> dict: ...
+```
+
+## 3. Capability Manifest (CM)
+
+The CM defines what an agent/scope is permitted to do:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| tool_allowlist | list[str] | Permitted tool identifiers |
+| tool_denylist | list[str] | Explicitly forbidden tools |
+| data_scopes | list[str] | Accessible data paths/datasets |
+| network_egress | list[str] | Permitted network destinations |
+| compute_quota | dict | Token/time/step limits |
+| memory_scope | dict | Memory access boundaries |
+| revocation_policy | str | How capabilities are revoked |
+
+## 4. Constraint Set (CS)
+
+The CS defines what is forbidden and what invariants must hold:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| forbidden_actions | list[str] | Explicitly forbidden action patterns |
+| invariants | list[str] | Conditions that must always hold |
+| veto_categories | list[str] | Categories eligible for veto |
+| appeal_windows | dict | Time windows for appeals per decision type |
+| emergency_profile | dict | Emergency-specific constraints |
+
+## 5. Sanctions Ladder
+
+| Level | Code | Name | Description |
+|-------|------|------|-------------|
+| S0 | WARN | Warning | Logged warning, no capability change |
+| S1 | THROTTLE | Throttle | Rate-limited actions |
+| S2 | RESTRICT_TOOLS | Restrict Tools | Specific tools removed from CM |
+| S3 | QUARANTINE | Quarantine | Isolated execution, no external effects |
+| S4 | SUSPEND_SCOPE | Suspend Scope | All capabilities suspended |
+| S5 | TERMINATE_INSTANCE | Terminate | Instance terminated |
+
+### 5.1 Escalation Rules
+
+- **Repeat violations**: Same violation type within window → escalate one level
+- **Severity thresholds**: Critical violations may skip levels (configurable)
+- **De-escalation**: After clean period, sanctions reduce one level
+- **Maximum**: S5 requires D2 governance decision to reverse
+
+## 6. Sandbox Enforcer (Reference Implementation)
+
+The `SandboxEnforcer` is the reference MV-EL implementation for simulations:
+
+### 6.1 Tool Enforcement
+- Maintains allowlist/denylist per scope
+- Checks tool invocations against CM before execution
+- Logs all denied attempts
+
+### 6.2 Data Scope Enforcement
+- Validates data access paths against CM data_scopes
+- Pattern matching for path-based access control
+
+### 6.3 Network Enforcement
+- Egress allowlist checking (stubbed for simulation)
+- All network attempts logged
+
+### 6.4 Compute Enforcement
+- Token/time/step tracking per scope
+- Quota enforcement with configurable limits
+
+### 6.5 Audit Integration
+- All enforcement actions logged to audit log as EP addenda
+- Sanction events produce their own audit entries
+
+## 7. Revocation Levels
+
+| Level | Name | Effect |
+|-------|------|--------|
+| THROTTLE | Throttle | Reduce rate limits |
+| RESTRICT | Restrict | Remove specific capabilities |
+| QUARANTINE | Quarantine | Isolate from external systems |
+| SUSPEND | Suspend | Halt all capability usage |
+| TERMINATE | Terminate | End scope entirely |
+
+## 8. Integration Points
+
+### 8.1 Action Execution Path
+
+```
+Agent requests action
+  → EnforcementInterface.check_action_allowed(action, context)
+    → CM check (tool in allowlist?)
+    → CS check (action not forbidden?)
+    → Quota check (within limits?)
+    → Return allow/deny + reason
+  → If allowed: execute + log
+  → If denied: log denial + check sanction escalation
+```
+
+### 8.2 Governance Decision Execution
+
+```
+GovernanceEngine.execute(decision)
+  → Verify EP complete
+  → EnforcementInterface.apply_capability_manifest(scope, new_cm)
+  → Log execution event
+```
+
+## 9. Security Notes
+
+**Simulation Stubs**: In simulation mode, cryptographic signatures and network enforcement are stubbed. These are architecturally represented with correct interfaces but use placeholder implementations. Production deployment requires replacing stubs with real implementations.
+
+## 10. References
+
+- [Meta-Concord MCX Specification](meta_concord_mcx.md)
+- [Threat Model](threat_model.md)

--- a/docs/governance/threat_model.md
+++ b/docs/governance/threat_model.md
@@ -1,0 +1,128 @@
+# MCX Threat Model
+
+> **Version**: 1.0.0
+> **Status**: Active
+
+## 1. Overview
+
+This document enumerates the primary threat categories for the Meta-Concord governance system and describes the mitigations implemented in the MCX + MV-EL architecture.
+
+## 2. Threat Categories
+
+### 2.1 Governance Capture
+
+**Threat**: A single party class (H, A, or I) accumulates enough voting power to pass decisions unilaterally, subverting multi-class representation.
+
+**Attack Vectors**:
+- Sybil attack: Creating multiple identities within one class
+- Collusion: Cross-party coordination to bypass class-wise assent
+- Admission flooding: Admitting many friendly parties to one class
+
+**Mitigations**:
+- **Class-wise assent requirement**: Every D1–D4 decision requires at least one approval from each class (H, A, I). No single class can pass decisions alone.
+- **Admission governance**: Adding parties requires D1 decision with full governance (supermajority + class-wise assent).
+- **Conflict disclosure**: Parties must declare conflicts of interest at registration.
+- **Quorum per class**: Minimum one party per class must be present for any governed decision.
+
+**Residual Risk**: Collusion across classes remains possible but requires compromising at least three parties across all classes.
+
+### 2.2 Emergency Abuse
+
+**Threat**: The emergency circuit breaker is used to bypass normal governance, effectively creating a permanent state of exception.
+
+**Attack Vectors**:
+- Indefinite emergency: Repeatedly renewing emergency state
+- Emergency as governance bypass: Making permanent changes during emergency
+- False emergency: Declaring emergency without genuine cause
+
+**Mitigations**:
+- **Multi-class entry**: Emergency requires approval from ≥1 H, ≥1 A, ≥1 I.
+- **Auto-expiry**: Emergency state expires after configurable time T+X.
+- **Escalating renewal thresholds**: Each renewal requires higher approval percentage.
+- **Mandatory audit on 2nd+ renewals**: Forces justification review.
+- **Irreversibility ban**: No irreversible actions during emergency (except via special higher-threshold exception).
+- **No permanent CS/CM changes**: Emergency changes must be reproposed as D1/D2 after exit.
+- **Post-hoc review**: Invalid emergency entry triggers automatic sanctions.
+
+**Residual Risk**: A genuine emergency may be hampered by threshold requirements. The escalating threshold design balances urgency against abuse.
+
+### 2.3 Audit Log Custody
+
+**Threat**: The audit log is tampered with to conceal illegitimate governance actions or fabricate legitimacy.
+
+**Attack Vectors**:
+- Entry modification: Changing historical entries
+- Entry deletion: Removing incriminating records
+- Selective disclosure: Publishing only favorable entries
+- Custody compromise: Gaining control of log signing keys
+
+**Mitigations**:
+- **Hash chain**: Each entry references the previous entry's hash, making modification detectable.
+- **Merkle roots**: Periodic Merkle root computation enables efficient integrity verification.
+- **Threshold custody**: Root signing requires m-of-n approvals across party classes.
+- **Append-only structure**: No delete or update operations exist in the log interface.
+- **Verifiable inclusion**: Any entry can be verified against Merkle proofs.
+- **External anchoring interface**: Merkle roots can be anchored to external systems (blockchain, notary services) for additional tamper evidence.
+
+**Residual Risk**: In simulation mode, cryptographic custody is stubbed. Production deployment must implement real key management.
+
+### 2.4 Appeals Denial of Service
+
+**Threat**: The appeals mechanism is abused to block or delay legitimate governance decisions indefinitely.
+
+**Attack Vectors**:
+- Appeal flooding: Filing many appeals on the same decision
+- Repeated identical objections: Stalling execution through repetition
+- Strategic timing: Filing appeals at critical moments to delay emergency responses
+
+**Mitigations**:
+- **Bonded objections**: Repeated identical objections trigger bonding requirements (increasing cost).
+- **Rate limiting**: Per-party limits on objection and appeal frequency.
+- **Admissibility filtering**: Appeals must state valid grounds; frivolous appeals are rejected.
+- **Time windows**: Appeals have configurable deadlines per decision type.
+- **Bonding for repeated appeals**: Each subsequent appeal on the same decision requires higher bonding.
+
+**Residual Risk**: Legitimate objections may be chilled by bonding requirements. The bonding curve is designed to be lenient for first objections.
+
+### 2.5 Transparency-by-Volume
+
+**Threat**: The audit log becomes so large that meaningful oversight is impractical, creating "transparency" that obscures rather than reveals.
+
+**Attack Vectors**:
+- Log flooding: Generating massive volumes of legitimate-looking entries
+- Complexity obfuscation: Embedding important changes in routine entries
+- Summary manipulation: Controlling what appears in bounded summaries
+
+**Mitigations**:
+- **Bounded summaries**: Configurable summary generation with verifiable detail pointers.
+- **Decision-type indexing**: Log entries are tagged by decision type for filtering.
+- **Merkle proofs**: Enable verification of specific entries without reading entire log.
+- **Structured EP format**: Standardized Evidence Packages make automated analysis feasible.
+
+**Residual Risk**: Sophisticated obfuscation within valid EP fields remains possible. External auditing tools should be developed for production use.
+
+## 3. Simulation vs Production Security
+
+| Component | Simulation | Production Required |
+|-----------|-----------|-------------------|
+| Signatures | SHA-256 hash stubs | Real asymmetric crypto (Ed25519/RSA) |
+| Key custody | In-memory dict | HSM / threshold signing service |
+| Network enforcement | Allowlist check (no real blocking) | Actual network policy enforcement |
+| Log anchoring | Local storage | External anchoring (blockchain/notary) |
+| Identity | String IDs | PKI-based identity |
+
+## 4. Testing Coverage
+
+The following tests validate threat mitigations:
+
+1. **Capture resistance**: Coalition of A parties cannot pass D1/D2 without H and I assent
+2. **Emergency abuse**: Tests for multi-class entry, auto-expiry, escalating renewal, irreversibility ban
+3. **Audit integrity**: Tamper detection via hash chain verification
+4. **Appeals DOS**: Bonding/rate limiting for repeated objections
+5. **Decision rules**: Class-wise assent and quorum enforcement
+
+## 5. References
+
+- [Meta-Concord MCX Specification](meta_concord_mcx.md)
+- [MV-EL Specification](mv_enforcement_layer.md)
+- [Evidence Package Schema](evidence_package_schema.md)

--- a/examples/mcx_governance_demo.py
+++ b/examples/mcx_governance_demo.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""
+Meta-Concord (MCX) Governance Demo
+
+Demonstrates the full MCX governance lifecycle:
+1. Register parties (H/A/I)
+2. Propose a D2 capability restriction
+3. Vote + generate Evidence Package
+4. Execute via enforcement layer
+5. Demonstrate objection + arbitration
+6. Demonstrate emergency entry + expiry
+
+Usage:
+    python examples/mcx_governance_demo.py
+
+Requires:
+    pip install -e .  (or PYTHONPATH includes src/)
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+
+# Ensure src is importable
+sys.path.insert(0, "src")
+
+from agisa_sac.governance.engine import GovernanceEngine
+from agisa_sac.governance.enforcement.sandbox import SandboxEnforcer
+from agisa_sac.governance.parties import Party
+from agisa_sac.governance.types import (
+    CapabilityManifest,
+    ConstraintSet,
+    DecisionType,
+    PartyClass,
+)
+from agisa_sac.governance.voting import VoteRecord
+
+
+def print_header(title: str) -> None:
+    print(f"\n{'=' * 60}")
+    print(f"  {title}")
+    print(f"{'=' * 60}")
+
+
+def print_result(result) -> None:
+    status = "LEGITIMATE" if result.legitimate else "ILLEGITIMATE"
+    print(f"  [{status}] {result.reason}")
+
+
+def main() -> int:
+    # ============================================================
+    # Setup
+    # ============================================================
+    print_header("MCX Governance Demo")
+
+    cs = ConstraintSet(
+        forbidden_actions=["delete_all_data", "bypass_governance"],
+        invariants=["audit_log_intact", "all_actions_logged"],
+    )
+    cm = CapabilityManifest(
+        tool_allowlist=["read_data", "write_data", "analyze", "report"],
+        data_scopes=["/data/*", "/reports/*"],
+        network_egress=["api.approved.com"],
+    )
+    engine = GovernanceEngine(cs=cs, cm=cm, emergency_expiry=30.0)
+
+    # ============================================================
+    # 1. Register Parties
+    # ============================================================
+    print_header("1. Register Parties")
+
+    parties = [
+        Party(id="alice", party_class=PartyClass.H, representation_scope=["*"]),
+        Party(id="bob", party_class=PartyClass.H, representation_scope=["*"]),
+        Party(id="agent-alpha", party_class=PartyClass.A, representation_scope=["*"]),
+        Party(id="agent-beta", party_class=PartyClass.A, representation_scope=["*"]),
+        Party(id="infra-monitor", party_class=PartyClass.I, representation_scope=["*"]),
+    ]
+
+    for party in parties:
+        result = engine.register_party(party)
+        print_result(result)
+
+    print(f"\n  Total parties: {len(engine.party_registry)}")
+    print(f"  Class counts: {engine.party_registry.class_counts()}")
+
+    # ============================================================
+    # 2. Propose D2 Capability Restriction
+    # ============================================================
+    print_header("2. Propose D2 Capability Restriction")
+
+    result = engine.propose_decision(
+        proposer_id="alice",
+        decision_type=DecisionType.D2,
+        payload={"target": "agent-alpha", "restriction": "remove network egress to *.external.com"},
+        rationale="Agent-alpha's network egress scope exceeds audited requirements.",
+        impact_statement="Agent-alpha loses access to undocumented external endpoints.",
+        cm_diff={
+            "removed": {"network_egress": ["*.external.com"]},
+            "modified": {"network_egress": ["api.approved.com"]},
+        },
+    )
+    print_result(result)
+    decision_id = result.decision_id
+    print(f"  Decision ID: {decision_id}")
+
+    # ============================================================
+    # 3. Vote
+    # ============================================================
+    print_header("3. Voting Phase")
+
+    votes = [
+        ("alice", True),
+        ("bob", True),
+        ("agent-alpha", True),
+        ("agent-beta", True),
+        ("infra-monitor", True),
+    ]
+
+    for party_id, approve in votes:
+        result = engine.cast_vote(decision_id, party_id, approve)
+        action = "approve" if approve else "reject"
+        print(f"  {party_id} votes to {action}")
+
+    # Evaluate
+    print("\n  Evaluating decision...")
+    eval_result = engine.evaluate_decision(decision_id)
+    print_result(eval_result)
+
+    # ============================================================
+    # 4. Execute with EP
+    # ============================================================
+    print_header("4. Execute Decision")
+
+    exec_result = engine.execute_decision(decision_id)
+    print_result(exec_result)
+    if exec_result.data.get("ep_id"):
+        print(f"  Evidence Package ID: {exec_result.data['ep_id']}")
+
+    # Verify audit
+    audit_result = engine.verify_decision_audit(decision_id)
+    print(f"  Audit verification: {audit_result}")
+
+    # ============================================================
+    # 5. Demonstrate Objection + Arbitration
+    # ============================================================
+    print_header("5. Objection + Arbitration Demo")
+
+    # Propose another decision
+    result2 = engine.propose_decision(
+        proposer_id="agent-beta",
+        decision_type=DecisionType.D2,
+        rationale="Expand agent-beta's compute quota",
+        impact_statement="Increases compute allocation by 50%",
+    )
+    did2 = result2.decision_id
+    print(f"  New decision: {did2}")
+
+    # File objection
+    obj_result = engine.file_objection(
+        decision_id=did2,
+        party_id="alice",
+        basis="inadequate_impact_statement",
+        detail="Impact statement does not address resource contention",
+    )
+    print_result(obj_result)
+
+    # Check state
+    decision2 = engine.get_decision(did2)
+    print(f"  Decision state: {decision2.state.value}")
+
+    # File repeated objection (triggers bonding)
+    obj2_result = engine.file_objection(
+        decision_id=did2,
+        party_id="alice",
+        basis="inadequate_impact_statement",
+        detail="Still inadequate",
+    )
+    print_result(obj2_result)
+    print("  (Note: bonding triggered for repeated objection)")
+
+    # Resolve and continue
+    engine.resolve_objection(did2)
+    print(f"  Decision state after resolution: {engine.get_decision(did2).state.value}")
+
+    # ============================================================
+    # 6. Emergency Entry + Expiry Demo
+    # ============================================================
+    print_header("6. Emergency Circuit Breaker Demo")
+
+    # Multi-class approval votes for emergency
+    emergency_votes = [
+        VoteRecord(party_id="alice", party_class=PartyClass.H, approve=True),
+        VoteRecord(party_id="agent-alpha", party_class=PartyClass.A, approve=True),
+        VoteRecord(party_id="infra-monitor", party_class=PartyClass.I, approve=True),
+    ]
+
+    emg_result = engine.enter_emergency(
+        votes=emergency_votes,
+        invariants=["no_external_network", "audit_required"],
+    )
+    print_result(emg_result)
+    print(f"  Emergency active: {engine.emergency_manager.is_active}")
+
+    # Try D1 during emergency (should fail)
+    d1_result = engine.propose_decision(
+        proposer_id="alice",
+        decision_type=DecisionType.D1,
+        rationale="Policy change during emergency",
+        impact_statement="test",
+    )
+    print(f"  D1 during emergency: {d1_result}")
+
+    # Renew emergency
+    renew_result = engine.renew_emergency(emergency_votes)
+    print_result(renew_result)
+    print(f"  Renewal count: {engine.emergency_manager.state.renewal_count}")
+    print(f"  Next renewal threshold: {engine.emergency_manager.get_renewal_threshold():.2%}")
+
+    # Exit emergency
+    exit_result = engine.exit_emergency()
+    print_result(exit_result)
+    print(f"  Emergency active: {engine.emergency_manager.is_active}")
+
+    # Check pending reviews
+    reviews = engine.emergency_manager.get_pending_reviews()
+    print(f"  Pending post-hoc reviews: {len(reviews)}")
+
+    # ============================================================
+    # 7. Capture Resistance Demo
+    # ============================================================
+    print_header("7. Capture Resistance Demo")
+
+    result3 = engine.propose_decision(
+        proposer_id="agent-alpha",
+        decision_type=DecisionType.D1,
+        rationale="Grant all agents unrestricted access",
+        impact_statement="Major capability expansion",
+    )
+    did3 = result3.decision_id
+
+    # Only agents approve
+    engine.cast_vote(did3, "agent-alpha", approve=True)
+    engine.cast_vote(did3, "agent-beta", approve=True)
+    engine.cast_vote(did3, "alice", approve=False)
+    engine.cast_vote(did3, "bob", approve=False)
+    engine.cast_vote(did3, "infra-monitor", approve=False)
+
+    eval3 = engine.evaluate_decision(did3)
+    print_result(eval3)
+    print("  (Correctly rejected: agent-only coalition cannot pass D1)")
+
+    # ============================================================
+    # 8. Audit Log Summary
+    # ============================================================
+    print_header("8. Audit Log Summary")
+
+    log_result = engine.verify_audit_log()
+    print_result(log_result)
+    print(f"  Total entries: {engine.audit_log.length}")
+
+    summary = engine.audit_log.get_bounded_summary(max_entries=10)
+    print(f"  Last {len(summary)} entries:")
+    for entry in summary:
+        print(f"    [{entry['event_type']}] {entry['summary']}")
+
+    # ============================================================
+    # Done
+    # ============================================================
+    print_header("Demo Complete")
+    print("  All governance operations demonstrated successfully.")
+    print("  Run tests with: pytest tests/governance/ -v")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/agisa_sac/cli.py
+++ b/src/agisa_sac/cli.py
@@ -239,6 +239,11 @@ def main() -> int:
         help="Fraction of agents to expose (default: 0.15)",
     )
 
+    # Concord governance commands
+    from agisa_sac.governance.cli import add_concord_subparser
+
+    add_concord_subparser(subparsers)
+
     # Parse arguments
     args = parser.parse_args()
 
@@ -269,6 +274,10 @@ def main() -> int:
     elif args.command == "list-presets":
         list_presets()
         return 0
+    elif args.command == "concord":
+        from agisa_sac.governance.cli import handle_concord
+
+        return handle_concord(args)
     elif args.command == "convert-transcript":
         from .cli.convert_transcript import convert_transcript
 

--- a/src/agisa_sac/governance/__init__.py
+++ b/src/agisa_sac/governance/__init__.py
@@ -1,0 +1,39 @@
+"""
+Meta-Concord (MCX) Governance System for AGI-SAC.
+
+This package implements constitutional, enforceable governance-of-governance
+with procedural legitimacy, multi-class representation, and verifiable audit trails.
+
+Enable via config: concord.mode = "mcx"
+"""
+
+from agisa_sac.governance.types import (
+    PartyClass,
+    DecisionType,
+    DecisionLifecycleState,
+    SanctionLevel,
+    RevocationLevel,
+    EmergencyStatus,
+)
+from agisa_sac.governance.parties import Party, PartyRegistry
+from agisa_sac.governance.decisions import Decision
+from agisa_sac.governance.voting import VoteRecord, QuorumProof, ThresholdProof
+from agisa_sac.governance.evidence import EvidencePackage
+from agisa_sac.governance.engine import GovernanceEngine
+
+__all__ = [
+    "PartyClass",
+    "DecisionType",
+    "DecisionLifecycleState",
+    "SanctionLevel",
+    "RevocationLevel",
+    "EmergencyStatus",
+    "Party",
+    "PartyRegistry",
+    "Decision",
+    "VoteRecord",
+    "QuorumProof",
+    "ThresholdProof",
+    "EvidencePackage",
+    "GovernanceEngine",
+]

--- a/src/agisa_sac/governance/appeals.py
+++ b/src/agisa_sac/governance/appeals.py
@@ -1,0 +1,161 @@
+"""Appeals handling for MCX governance.
+
+Appeals allow parties to challenge decision outcomes. Subject to
+admissibility filtering, rate limiting, and bonding for repeated appeals.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from agisa_sac.governance.types import (
+    DEFAULT_APPEAL_BOND_BASE,
+    DEFAULT_APPEAL_BOND_MULTIPLIER,
+    DEFAULT_APPEAL_WINDOW_SECONDS,
+)
+
+logger = logging.getLogger(__name__)
+
+VALID_APPEAL_GROUNDS: List[str] = [
+    "procedural_error",
+    "new_evidence",
+    "threshold_miscalculation",
+    "conflict_of_interest",
+    "inadequate_review",
+]
+
+
+@dataclass
+class Appeal:
+    """A formal appeal of a governance decision outcome."""
+
+    appeal_id: str = ""
+    decision_id: str = ""
+    party_id: str = ""
+    grounds: str = ""
+    detail: str = ""
+    timestamp: float = field(default_factory=time.time)
+    bond_amount: float = 0.0
+    admissible: bool = False
+    resolution: Optional[str] = None  # "upheld", "overturned", "dismissed"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "appeal_id": self.appeal_id,
+            "decision_id": self.decision_id,
+            "party_id": self.party_id,
+            "grounds": self.grounds,
+            "detail": self.detail,
+            "timestamp": self.timestamp,
+            "bond_amount": self.bond_amount,
+            "admissible": self.admissible,
+            "resolution": self.resolution,
+        }
+
+
+class AppealTracker:
+    """Manages appeals with admissibility filtering and bonding."""
+
+    def __init__(
+        self,
+        appeal_window: float = DEFAULT_APPEAL_WINDOW_SECONDS,
+        bond_base: float = DEFAULT_APPEAL_BOND_BASE,
+        bond_multiplier: float = DEFAULT_APPEAL_BOND_MULTIPLIER,
+    ) -> None:
+        self.appeal_window = appeal_window
+        self.bond_base = bond_base
+        self.bond_multiplier = bond_multiplier
+        # decision_id -> list of appeals
+        self._appeals: Dict[str, List[Appeal]] = {}
+
+    def file_appeal(
+        self,
+        decision_id: str,
+        party_id: str,
+        grounds: str,
+        detail: str = "",
+        decision_approved_at: Optional[float] = None,
+    ) -> Appeal:
+        """File an appeal against a decision.
+
+        Args:
+            decision_id: ID of the decision being appealed.
+            party_id: ID of the appealing party.
+            grounds: Must be one of VALID_APPEAL_GROUNDS.
+            detail: Additional detail.
+            decision_approved_at: When the decision was approved/rejected
+                (for window check).
+
+        Returns:
+            The filed Appeal.
+
+        Raises:
+            ValueError: If grounds invalid, window expired, or other issues.
+        """
+        if grounds not in VALID_APPEAL_GROUNDS:
+            raise ValueError(
+                f"Invalid appeal grounds: '{grounds}'. "
+                f"Valid grounds: {VALID_APPEAL_GROUNDS}"
+            )
+
+        now = time.time()
+
+        # Check appeal window
+        if decision_approved_at is not None:
+            if now - decision_approved_at > self.appeal_window:
+                raise ValueError(
+                    f"Appeal window expired. Decision was finalized "
+                    f"{now - decision_approved_at:.0f}s ago "
+                    f"(window: {self.appeal_window:.0f}s)"
+                )
+
+        # Calculate bond based on number of prior appeals on this decision
+        prior = self._appeals.get(decision_id, [])
+        party_prior = [a for a in prior if a.party_id == party_id]
+        count = len(party_prior)
+        bond_amount = 0.0
+        if count > 0:
+            bond_amount = self.bond_base * (self.bond_multiplier**count)
+
+        appeal = Appeal(
+            appeal_id=f"appeal-{decision_id}-{len(prior) + 1}",
+            decision_id=decision_id,
+            party_id=party_id,
+            grounds=grounds,
+            detail=detail,
+            timestamp=now,
+            bond_amount=bond_amount,
+            admissible=True,
+        )
+
+        if decision_id not in self._appeals:
+            self._appeals[decision_id] = []
+        self._appeals[decision_id].append(appeal)
+
+        logger.info(
+            "Appeal filed: %s by %s on decision %s (grounds=%s, bond=%.2f)",
+            appeal.appeal_id,
+            party_id,
+            decision_id,
+            grounds,
+            bond_amount,
+        )
+        return appeal
+
+    def get_appeals(self, decision_id: str) -> List[Appeal]:
+        """Get all appeals for a decision."""
+        return self._appeals.get(decision_id, [])
+
+    def resolve_appeal(
+        self, appeal_id: str, decision_id: str, resolution: str
+    ) -> None:
+        """Resolve an appeal."""
+        for appeal in self._appeals.get(decision_id, []):
+            if appeal.appeal_id == appeal_id:
+                appeal.resolution = resolution
+                logger.info("Appeal %s resolved: %s", appeal_id, resolution)
+                return
+        raise ValueError(f"Appeal {appeal_id} not found for decision {decision_id}")

--- a/src/agisa_sac/governance/auditlog.py
+++ b/src/agisa_sac/governance/auditlog.py
@@ -1,0 +1,286 @@
+"""Append-only audit log with hash chain and Merkle root anchoring.
+
+Provides tamper-evident logging for all governance actions. Each entry
+references the previous entry's hash, forming a hash chain. Periodic
+Merkle root computation enables efficient integrity verification.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import math
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Genesis hash for the first entry
+GENESIS_HASH = "0" * 64
+
+
+@dataclass
+class AuditEntry:
+    """A single append-only audit log entry."""
+
+    entry_id: str = field(default_factory=lambda: f"log-{uuid.uuid4().hex[:12]}")
+    timestamp: float = field(default_factory=time.time)
+    event_type: str = ""  # e.g., "decision_proposed", "vote_cast", "ep_created"
+    decision_id: Optional[str] = None
+    actor_id: Optional[str] = None
+    data: Dict[str, Any] = field(default_factory=dict)
+    previous_hash: str = GENESIS_HASH
+    entry_hash: str = ""
+    summary: str = ""
+
+    def compute_hash(self) -> str:
+        """Compute the hash of this entry (excluding entry_hash itself)."""
+        content = {
+            "entry_id": self.entry_id,
+            "timestamp": self.timestamp,
+            "event_type": self.event_type,
+            "decision_id": self.decision_id,
+            "actor_id": self.actor_id,
+            "data": self.data,
+            "previous_hash": self.previous_hash,
+        }
+        serialized = json.dumps(content, sort_keys=True, default=str)
+        return hashlib.sha256(serialized.encode()).hexdigest()
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "entry_id": self.entry_id,
+            "timestamp": self.timestamp,
+            "event_type": self.event_type,
+            "decision_id": self.decision_id,
+            "actor_id": self.actor_id,
+            "data": self.data,
+            "previous_hash": self.previous_hash,
+            "entry_hash": self.entry_hash,
+            "summary": self.summary,
+        }
+
+
+class AuditLog:
+    """Append-only audit log with hash chain integrity.
+
+    Features:
+    - Hash chain: each entry references previous entry's hash.
+    - Merkle roots: periodic computation for efficient verification.
+    - Bounded summaries: configurable summary generation.
+    - Verifiable inclusion: Merkle proofs for specific entries.
+    - External anchoring interface (stub).
+    """
+
+    def __init__(self, merkle_interval: int = 10) -> None:
+        """Initialize audit log.
+
+        Args:
+            merkle_interval: Compute Merkle root every N entries.
+        """
+        self._entries: List[AuditEntry] = []
+        self._merkle_roots: List[Dict[str, Any]] = []
+        self._merkle_interval = merkle_interval
+        self._anchored_roots: List[Dict[str, Any]] = []
+
+    @property
+    def entries(self) -> List[AuditEntry]:
+        return list(self._entries)
+
+    @property
+    def length(self) -> int:
+        return len(self._entries)
+
+    def append(
+        self,
+        event_type: str,
+        data: Dict[str, Any],
+        decision_id: Optional[str] = None,
+        actor_id: Optional[str] = None,
+        summary: str = "",
+    ) -> AuditEntry:
+        """Append a new entry to the audit log.
+
+        The entry's hash is automatically computed and chained to
+        the previous entry.
+
+        Returns:
+            The newly appended AuditEntry.
+        """
+        previous_hash = (
+            self._entries[-1].entry_hash if self._entries else GENESIS_HASH
+        )
+
+        entry = AuditEntry(
+            event_type=event_type,
+            decision_id=decision_id,
+            actor_id=actor_id,
+            data=data,
+            previous_hash=previous_hash,
+            summary=summary or f"{event_type}: {decision_id or 'system'}",
+        )
+        entry.entry_hash = entry.compute_hash()
+        self._entries.append(entry)
+
+        # Check if we should compute a Merkle root
+        if len(self._entries) % self._merkle_interval == 0:
+            root = self._compute_merkle_root()
+            self._merkle_roots.append({
+                "root_hash": root,
+                "entry_count": len(self._entries),
+                "timestamp": time.time(),
+            })
+
+        return entry
+
+    def verify_log_integrity(self) -> bool:
+        """Verify the entire hash chain integrity.
+
+        Returns True if the chain is valid, False if tampered.
+        """
+        if not self._entries:
+            return True
+
+        # First entry should reference genesis
+        if self._entries[0].previous_hash != GENESIS_HASH:
+            logger.error("First entry does not reference genesis hash")
+            return False
+
+        for i, entry in enumerate(self._entries):
+            # Verify entry hash
+            expected_hash = entry.compute_hash()
+            if entry.entry_hash != expected_hash:
+                logger.error(
+                    "Entry %d (%s) hash mismatch: stored=%s computed=%s",
+                    i,
+                    entry.entry_id,
+                    entry.entry_hash,
+                    expected_hash,
+                )
+                return False
+
+            # Verify chain link (except first entry)
+            if i > 0:
+                if entry.previous_hash != self._entries[i - 1].entry_hash:
+                    logger.error(
+                        "Entry %d chain broken: previous_hash=%s "
+                        "but entry %d hash=%s",
+                        i,
+                        entry.previous_hash,
+                        i - 1,
+                        self._entries[i - 1].entry_hash,
+                    )
+                    return False
+
+        return True
+
+    def verify_entry_inclusion(self, entry_id: str) -> bool:
+        """Verify that a specific entry is included in the log with valid chain.
+
+        This is a simplified inclusion check. A full implementation would
+        use Merkle proofs for O(log n) verification.
+        """
+        for i, entry in enumerate(self._entries):
+            if entry.entry_id == entry_id:
+                # Verify this entry's hash
+                if entry.entry_hash != entry.compute_hash():
+                    return False
+                # Verify chain to this point
+                if i > 0 and entry.previous_hash != self._entries[i - 1].entry_hash:
+                    return False
+                return True
+        return False  # Entry not found
+
+    def get_entry(self, entry_id: str) -> Optional[AuditEntry]:
+        """Get a specific entry by ID."""
+        for entry in self._entries:
+            if entry.entry_id == entry_id:
+                return entry
+        return None
+
+    def get_entries_by_decision(self, decision_id: str) -> List[AuditEntry]:
+        """Get all entries related to a specific decision."""
+        return [e for e in self._entries if e.decision_id == decision_id]
+
+    def get_bounded_summary(
+        self, max_entries: int = 50
+    ) -> List[Dict[str, Any]]:
+        """Get a bounded summary of recent log entries.
+
+        Provides human-readable summaries with verifiable detail pointers
+        to mitigate transparency-by-volume attacks.
+        """
+        recent = self._entries[-max_entries:]
+        return [
+            {
+                "entry_id": e.entry_id,
+                "timestamp": e.timestamp,
+                "event_type": e.event_type,
+                "summary": e.summary,
+                "entry_hash": e.entry_hash,
+            }
+            for e in recent
+        ]
+
+    def get_merkle_roots(self) -> List[Dict[str, Any]]:
+        """Get all computed Merkle roots."""
+        return list(self._merkle_roots)
+
+    def anchor_root(self, root_hash: str) -> str:
+        """Anchor a Merkle root to an external system.
+
+        Simulation stub: records the anchoring request locally.
+        Production: would submit to blockchain, notary service, etc.
+
+        Returns:
+            Anchor reference ID.
+        """
+        anchor_ref = f"anchor-{uuid.uuid4().hex[:8]}"
+        self._anchored_roots.append({
+            "anchor_ref": anchor_ref,
+            "root_hash": root_hash,
+            "timestamp": time.time(),
+            "status": "anchored_stub",
+        })
+        logger.info(
+            "Root anchored (stub): %s -> %s", root_hash[:16], anchor_ref
+        )
+        return anchor_ref
+
+    def _compute_merkle_root(self) -> str:
+        """Compute a Merkle root over all current entry hashes."""
+        if not self._entries:
+            return GENESIS_HASH
+
+        hashes = [e.entry_hash for e in self._entries]
+        return _merkle_root(hashes)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "entries": [e.to_dict() for e in self._entries],
+            "merkle_roots": self._merkle_roots,
+            "anchored_roots": self._anchored_roots,
+            "merkle_interval": self._merkle_interval,
+        }
+
+
+def _merkle_root(hashes: List[str]) -> str:
+    """Compute Merkle root from a list of hashes."""
+    if not hashes:
+        return GENESIS_HASH
+    if len(hashes) == 1:
+        return hashes[0]
+
+    # Pad to even number
+    if len(hashes) % 2 == 1:
+        hashes = hashes + [hashes[-1]]
+
+    next_level: List[str] = []
+    for i in range(0, len(hashes), 2):
+        combined = hashes[i] + hashes[i + 1]
+        next_level.append(hashlib.sha256(combined.encode()).hexdigest())
+
+    return _merkle_root(next_level)

--- a/src/agisa_sac/governance/cli.py
+++ b/src/agisa_sac/governance/cli.py
@@ -1,0 +1,335 @@
+"""CLI commands for MCX governance.
+
+Provides the 'concord' subcommand group for the agisa-sac CLI.
+Commands: init, party, propose, vote, object, appeal, execute, audit, emergency.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Module-level engine instance (initialized by 'concord init')
+_engine = None
+
+
+def _get_engine():
+    """Lazy-import and return the governance engine."""
+    global _engine
+    if _engine is None:
+        from agisa_sac.governance.engine import GovernanceEngine
+
+        _engine = GovernanceEngine()
+    return _engine
+
+
+def _print_result(result: Any) -> None:
+    """Print a GovernanceResult with legitimacy status."""
+    status = "LEGITIMATE" if result.legitimate else "ILLEGITIMATE"
+    print(f"[{status}] {result.reason}")
+    if result.data:
+        # Print compact JSON for data
+        for key, value in result.data.items():
+            if isinstance(value, dict):
+                print(f"  {key}: {json.dumps(value, indent=2, default=str)}")
+            else:
+                print(f"  {key}: {value}")
+
+
+def add_concord_subparser(subparsers: Any) -> None:
+    """Add the 'concord' subcommand group to the CLI parser."""
+    concord_parser = subparsers.add_parser(
+        "concord",
+        help="Meta-Concord (MCX) governance commands",
+    )
+    concord_sub = concord_parser.add_subparsers(dest="concord_command")
+
+    # concord init
+    init_p = concord_sub.add_parser("init", help="Initialize MCX governance")
+    init_p.add_argument(
+        "--profile",
+        type=str,
+        default="simulation",
+        help="Configuration profile (simulation/production)",
+    )
+
+    # concord party add
+    party_p = concord_sub.add_parser("party", help="Party management")
+    party_sub = party_p.add_subparsers(dest="party_command")
+
+    add_p = party_sub.add_parser("add", help="Register a party")
+    add_p.add_argument("--class", dest="party_class", choices=["H", "A", "I"], required=True)
+    add_p.add_argument("--id", dest="party_id", required=True)
+    add_p.add_argument("--scope", nargs="*", default=["*"])
+
+    rm_p = party_sub.add_parser("remove", help="Remove a party")
+    rm_p.add_argument("--id", dest="party_id", required=True)
+
+    list_p = party_sub.add_parser("list", help="List all parties")
+
+    # concord propose
+    propose_p = concord_sub.add_parser("propose", help="Propose a governance decision")
+    propose_p.add_argument("--type", dest="dtype", choices=["D1", "D2", "D3", "D4"], required=True)
+    propose_p.add_argument("--proposer", required=True, help="Proposer party ID")
+    propose_p.add_argument("--rationale", required=True)
+    propose_p.add_argument("--impact", dest="impact_statement", required=True)
+    propose_p.add_argument("--payload", type=str, default="{}", help="JSON payload")
+
+    # concord vote
+    vote_p = concord_sub.add_parser("vote", help="Cast a vote on a decision")
+    vote_p.add_argument("--decision-id", required=True)
+    vote_p.add_argument("--party-id", required=True)
+    vote_grp = vote_p.add_mutually_exclusive_group(required=True)
+    vote_grp.add_argument("--approve", action="store_true")
+    vote_grp.add_argument("--deny", action="store_true")
+
+    # concord object
+    obj_p = concord_sub.add_parser("object", help="File an objection")
+    obj_p.add_argument("--decision-id", required=True)
+    obj_p.add_argument("--party-id", required=True)
+    obj_p.add_argument("--reason", required=True, dest="basis")
+    obj_p.add_argument("--detail", default="")
+    obj_p.add_argument("--veto", action="store_true")
+    obj_p.add_argument("--veto-category", default=None)
+
+    # concord appeal
+    appeal_p = concord_sub.add_parser("appeal", help="File an appeal")
+    appeal_p.add_argument("--decision-id", required=True)
+    appeal_p.add_argument("--party-id", required=True)
+    appeal_p.add_argument("--grounds", required=True)
+    appeal_p.add_argument("--detail", default="")
+
+    # concord execute
+    exec_p = concord_sub.add_parser("execute", help="Execute an approved decision")
+    exec_p.add_argument("--decision-id", required=True)
+
+    # concord evaluate
+    eval_p = concord_sub.add_parser("evaluate", help="Evaluate if a decision meets requirements")
+    eval_p.add_argument("--decision-id", required=True)
+
+    # concord audit
+    audit_p = concord_sub.add_parser("audit", help="Audit operations")
+    audit_sub = audit_p.add_subparsers(dest="audit_command")
+
+    verify_p = audit_sub.add_parser("verify", help="Verify audit log or decision")
+    verify_p.add_argument("--decision-id", default=None)
+    verify_p.add_argument("--log", action="store_true", help="Verify full log")
+
+    summary_p = audit_sub.add_parser("summary", help="Show audit log summary")
+    summary_p.add_argument("--max-entries", type=int, default=50)
+
+    # concord emergency
+    emerg_p = concord_sub.add_parser("emergency", help="Emergency circuit breaker")
+    emerg_sub = emerg_p.add_subparsers(dest="emergency_command")
+    emerg_sub.add_parser("enter", help="Enter emergency (requires D3)")
+    emerg_sub.add_parser("renew", help="Renew emergency")
+    emerg_sub.add_parser("exit", help="Exit emergency")
+    emerg_sub.add_parser("status", help="Show emergency status")
+
+    # concord status
+    concord_sub.add_parser("status", help="Show governance status overview")
+
+
+def handle_concord(args: argparse.Namespace) -> int:
+    """Handle the 'concord' subcommand."""
+    cmd = getattr(args, "concord_command", None)
+    if cmd is None:
+        print("Usage: agisa-sac concord <command>")
+        print("Commands: init, party, propose, vote, object, appeal, execute, evaluate, audit, emergency, status")
+        return 1
+
+    engine = _get_engine()
+
+    if cmd == "init":
+        return _handle_init(args, engine)
+    elif cmd == "party":
+        return _handle_party(args, engine)
+    elif cmd == "propose":
+        return _handle_propose(args, engine)
+    elif cmd == "vote":
+        return _handle_vote(args, engine)
+    elif cmd == "object":
+        return _handle_object(args, engine)
+    elif cmd == "appeal":
+        return _handle_appeal(args, engine)
+    elif cmd == "execute":
+        return _handle_execute(args, engine)
+    elif cmd == "evaluate":
+        return _handle_evaluate(args, engine)
+    elif cmd == "audit":
+        return _handle_audit(args, engine)
+    elif cmd == "emergency":
+        return _handle_emergency(args, engine)
+    elif cmd == "status":
+        return _handle_status(engine)
+    else:
+        print(f"Unknown concord command: {cmd}")
+        return 1
+
+
+def _handle_init(args: argparse.Namespace, engine: Any) -> int:
+    profile = args.profile
+    print(f"MCX Governance initialized with profile: {profile}")
+    print(f"  Mode: mcx")
+    print(f"  Engine ready: {engine is not None}")
+    return 0
+
+
+def _handle_party(args: argparse.Namespace, engine: Any) -> int:
+    from agisa_sac.governance.parties import Party
+    from agisa_sac.governance.types import PartyClass
+
+    party_cmd = getattr(args, "party_command", None)
+    if party_cmd == "add":
+        party = Party(
+            id=args.party_id,
+            party_class=PartyClass(args.party_class),
+            representation_scope=args.scope,
+        )
+        result = engine.register_party(party)
+        _print_result(result)
+        return 0 if result.legitimate else 1
+    elif party_cmd == "remove":
+        result = engine.remove_party(args.party_id)
+        _print_result(result)
+        return 0 if result.legitimate else 1
+    elif party_cmd == "list":
+        parties = engine.party_registry.parties
+        if not parties:
+            print("No parties registered.")
+        for pid, p in parties.items():
+            print(f"  {pid}: class={p.party_class.value}, scope={p.representation_scope}")
+        return 0
+    else:
+        print("Usage: agisa-sac concord party <add|remove|list>")
+        return 1
+
+
+def _handle_propose(args: argparse.Namespace, engine: Any) -> int:
+    from agisa_sac.governance.types import DecisionType
+
+    payload = json.loads(args.payload) if args.payload else {}
+    result = engine.propose_decision(
+        proposer_id=args.proposer,
+        decision_type=DecisionType(args.dtype),
+        payload=payload,
+        rationale=args.rationale,
+        impact_statement=args.impact_statement,
+    )
+    _print_result(result)
+    return 0 if result.legitimate else 1
+
+
+def _handle_vote(args: argparse.Namespace, engine: Any) -> int:
+    result = engine.cast_vote(
+        decision_id=args.decision_id,
+        party_id=args.party_id,
+        approve=args.approve,
+    )
+    _print_result(result)
+    return 0 if result.legitimate else 1
+
+
+def _handle_object(args: argparse.Namespace, engine: Any) -> int:
+    result = engine.file_objection(
+        decision_id=args.decision_id,
+        party_id=args.party_id,
+        basis=args.basis,
+        detail=args.detail,
+        is_veto=args.veto,
+        veto_category=args.veto_category,
+    )
+    _print_result(result)
+    return 0 if result.legitimate else 1
+
+
+def _handle_appeal(args: argparse.Namespace, engine: Any) -> int:
+    result = engine.file_appeal(
+        decision_id=args.decision_id,
+        party_id=args.party_id,
+        grounds=args.grounds,
+        detail=args.detail,
+    )
+    _print_result(result)
+    return 0 if result.legitimate else 1
+
+
+def _handle_execute(args: argparse.Namespace, engine: Any) -> int:
+    result = engine.execute_decision(decision_id=args.decision_id)
+    _print_result(result)
+    return 0 if result.legitimate else 1
+
+
+def _handle_evaluate(args: argparse.Namespace, engine: Any) -> int:
+    result = engine.evaluate_decision(decision_id=args.decision_id)
+    _print_result(result)
+    return 0 if result.legitimate else 1
+
+
+def _handle_audit(args: argparse.Namespace, engine: Any) -> int:
+    audit_cmd = getattr(args, "audit_command", None)
+    if audit_cmd == "verify":
+        if args.log:
+            result = engine.verify_audit_log()
+        elif args.decision_id:
+            result = engine.verify_decision_audit(args.decision_id)
+        else:
+            print("Specify --log or --decision-id")
+            return 1
+        _print_result(result)
+        return 0 if result.legitimate else 1
+    elif audit_cmd == "summary":
+        summary = engine.audit_log.get_bounded_summary(
+            max_entries=args.max_entries
+        )
+        for entry in summary:
+            print(
+                f"  [{entry['event_type']}] {entry['summary']} "
+                f"(hash: {entry['entry_hash'][:12]}...)"
+            )
+        return 0
+    else:
+        print("Usage: agisa-sac concord audit <verify|summary>")
+        return 1
+
+
+def _handle_emergency(args: argparse.Namespace, engine: Any) -> int:
+    emerg_cmd = getattr(args, "emergency_command", None)
+    if emerg_cmd == "status":
+        state = engine.emergency_manager.state
+        print(f"  Status: {state.status.value}")
+        if state.status.value == "EMERGENCY":
+            print(f"  Entered at: {state.entered_at}")
+            print(f"  Expires at: {state.expires_at}")
+            print(f"  Renewals: {state.renewal_count}")
+            print(f"  Active: {state.is_active}")
+        return 0
+    elif emerg_cmd == "exit":
+        result = engine.exit_emergency()
+        _print_result(result)
+        return 0 if result.legitimate else 1
+    elif emerg_cmd in ("enter", "renew"):
+        print(
+            f"Emergency {emerg_cmd} requires programmatic vote submission. "
+            f"Use the Python API or demo script."
+        )
+        return 1
+    else:
+        print("Usage: agisa-sac concord emergency <enter|renew|exit|status>")
+        return 1
+
+
+def _handle_status(engine: Any) -> int:
+    print("=== MCX Governance Status ===")
+    print(f"  Parties: {len(engine.party_registry)}")
+    counts = engine.party_registry.class_counts()
+    print(f"  Class counts: H={counts['H']}, A={counts['A']}, I={counts['I']}")
+    print(f"  Decisions: {len(engine.get_all_decisions())}")
+    print(f"  Audit log entries: {engine.audit_log.length}")
+    print(f"  Emergency: {engine.emergency_manager.state.status.value}")
+    return 0

--- a/src/agisa_sac/governance/custody.py
+++ b/src/agisa_sac/governance/custody.py
@@ -1,0 +1,152 @@
+"""Threshold custody interfaces for MCX governance.
+
+Implements m-of-n threshold signing for audit log root anchoring.
+Simulation mode uses stub implementations with SHA-256 hashes.
+Production deployment should replace with real key management (HSM, etc.).
+
+IMPORTANT: This is a simulation stub. Do NOT use for real cryptographic
+security. The interfaces are architecturally correct but the implementations
+are placeholders.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from agisa_sac.governance.types import PartyClass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CustodyShare:
+    """A single custodian's share/key.
+
+    Simulation stub: the 'key' is just an identifier string.
+    Production: would hold actual key material or HSM references.
+    """
+
+    party_id: str
+    party_class: PartyClass
+    key_id: str = ""
+    # Simulation stub: no real key material
+    _stub_key: str = field(default="", repr=False)
+
+    def sign(self, data: str) -> str:
+        """Sign data with this custodian's key.
+
+        Simulation stub: returns SHA-256 hash of key_id + data.
+        """
+        content = f"{self.key_id}:{data}"
+        return f"stub-sig:{hashlib.sha256(content.encode()).hexdigest()[:32]}"
+
+
+class ThresholdCustody:
+    """M-of-N threshold custody for root signing.
+
+    Requires signatures from m custodians out of n total, with at least
+    one signature from each party class (H/A/I) for cross-class assurance.
+
+    Simulation stub: uses SHA-256 hash-based signatures.
+    """
+
+    def __init__(self, threshold_m: int = 2, total_n: int = 3) -> None:
+        self.threshold_m = threshold_m
+        self.total_n = total_n
+        self._shares: Dict[str, CustodyShare] = {}
+
+    def add_custodian(self, share: CustodyShare) -> None:
+        """Register a custodian."""
+        if len(self._shares) >= self.total_n:
+            raise ValueError(
+                f"Maximum custodians ({self.total_n}) already registered"
+            )
+        self._shares[share.party_id] = share
+        logger.info(
+            "Custodian registered: %s (class=%s)",
+            share.party_id,
+            share.party_class.value,
+        )
+
+    def sign_root(
+        self,
+        root_hash: str,
+        signing_party_ids: List[str],
+    ) -> Dict[str, Any]:
+        """Sign a Merkle root with threshold custody.
+
+        Requires m-of-n signatures with cross-class representation.
+
+        Args:
+            root_hash: The Merkle root hash to sign.
+            signing_party_ids: IDs of parties providing signatures.
+
+        Returns:
+            Dict with signatures, satisfaction status, and combined signature.
+
+        Raises:
+            ValueError: If threshold requirements not met.
+        """
+        if len(signing_party_ids) < self.threshold_m:
+            raise ValueError(
+                f"Need at least {self.threshold_m} signers, "
+                f"got {len(signing_party_ids)}"
+            )
+
+        signatures: List[Dict[str, str]] = []
+        signing_classes: set[str] = set()
+
+        for pid in signing_party_ids:
+            share = self._shares.get(pid)
+            if share is None:
+                raise ValueError(f"Party '{pid}' is not a registered custodian")
+            sig = share.sign(root_hash)
+            signatures.append({
+                "party_id": pid,
+                "party_class": share.party_class.value,
+                "signature": sig,
+            })
+            signing_classes.add(share.party_class.value)
+
+        # Check cross-class requirement
+        all_classes = len(signing_classes) >= min(
+            3, len(set(s.party_class.value for s in self._shares.values()))
+        )
+
+        # Combined signature (simulation: hash of all individual signatures)
+        combined = hashlib.sha256(
+            ":".join(s["signature"] for s in signatures).encode()
+        ).hexdigest()
+
+        result = {
+            "root_hash": root_hash,
+            "signatures": signatures,
+            "threshold_met": len(signatures) >= self.threshold_m,
+            "cross_class_met": all_classes,
+            "satisfied": len(signatures) >= self.threshold_m and all_classes,
+            "combined_signature": f"stub-combined:{combined[:32]}",
+        }
+
+        if result["satisfied"]:
+            logger.info("Root signed successfully: %s", root_hash[:16])
+        else:
+            logger.warning("Root signing incomplete: %s", result)
+
+        return result
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "threshold_m": self.threshold_m,
+            "total_n": self.total_n,
+            "custodians": {
+                pid: {
+                    "party_id": s.party_id,
+                    "party_class": s.party_class.value,
+                    "key_id": s.key_id,
+                }
+                for pid, s in self._shares.items()
+            },
+        }

--- a/src/agisa_sac/governance/deadlock.py
+++ b/src/agisa_sac/governance/deadlock.py
@@ -1,0 +1,158 @@
+"""Deadlock resolution for MCX governance.
+
+Implements the three-stage deadlock ladder:
+1. Mediation (timeboxed structured dialogue)
+2. Arbitration (mixed-class panel binding decision)
+3. Default-to-Safety (more restrictive CM/CS until resolved)
+"""
+
+from __future__ import annotations
+
+import enum
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from agisa_sac.governance.types import CapabilityManifest, ConstraintSet
+
+logger = logging.getLogger(__name__)
+
+
+class DeadlockStage(str, enum.Enum):
+    """Stages of the deadlock resolution ladder."""
+
+    NONE = "NONE"
+    MEDIATION = "MEDIATION"
+    ARBITRATION = "ARBITRATION"
+    DEFAULT_TO_SAFETY = "DEFAULT_TO_SAFETY"
+
+
+@dataclass
+class DeadlockState:
+    """Tracks the deadlock resolution state for a decision."""
+
+    decision_id: str = ""
+    stage: DeadlockStage = DeadlockStage.NONE
+    mediation_started_at: Optional[float] = None
+    mediation_deadline: Optional[float] = None
+    arbitration_panel: List[str] = field(default_factory=list)
+    arbitration_result: Optional[str] = None
+    safety_cm_applied: bool = False
+    safety_cs_applied: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "decision_id": self.decision_id,
+            "stage": self.stage.value,
+            "mediation_started_at": self.mediation_started_at,
+            "mediation_deadline": self.mediation_deadline,
+            "arbitration_panel": self.arbitration_panel,
+            "arbitration_result": self.arbitration_result,
+            "safety_cm_applied": self.safety_cm_applied,
+            "safety_cs_applied": self.safety_cs_applied,
+        }
+
+
+class DeadlockResolver:
+    """Manages the deadlock resolution ladder.
+
+    Config:
+        mediation_timeout: Seconds before mediation expires (default 600).
+    """
+
+    def __init__(self, mediation_timeout: float = 600.0) -> None:
+        self.mediation_timeout = mediation_timeout
+        self._states: Dict[str, DeadlockState] = {}
+
+    def start_mediation(self, decision_id: str) -> DeadlockState:
+        """Begin mediation for a deadlocked decision."""
+        now = time.time()
+        state = DeadlockState(
+            decision_id=decision_id,
+            stage=DeadlockStage.MEDIATION,
+            mediation_started_at=now,
+            mediation_deadline=now + self.mediation_timeout,
+        )
+        self._states[decision_id] = state
+        logger.info(
+            "Mediation started for decision %s (deadline: %.0fs)",
+            decision_id,
+            self.mediation_timeout,
+        )
+        return state
+
+    def escalate_to_arbitration(
+        self, decision_id: str, panel_party_ids: List[str]
+    ) -> DeadlockState:
+        """Escalate to arbitration with a mixed-class panel.
+
+        The panel should include members from at least 2 different classes.
+        """
+        state = self._states.get(decision_id)
+        if state is None:
+            state = DeadlockState(decision_id=decision_id)
+
+        state.stage = DeadlockStage.ARBITRATION
+        state.arbitration_panel = panel_party_ids
+        self._states[decision_id] = state
+        logger.info(
+            "Arbitration started for decision %s (panel: %s)",
+            decision_id,
+            panel_party_ids,
+        )
+        return state
+
+    def apply_default_to_safety(
+        self,
+        decision_id: str,
+        restricted_cm: Optional[CapabilityManifest] = None,
+        restricted_cs: Optional[ConstraintSet] = None,
+    ) -> DeadlockState:
+        """Apply default-to-safety: more restrictive CM/CS until resolution.
+
+        This is the final stage of deadlock resolution. It does not resolve
+        the decision but ensures safe operation while resolution continues.
+        """
+        state = self._states.get(decision_id)
+        if state is None:
+            state = DeadlockState(decision_id=decision_id)
+
+        state.stage = DeadlockStage.DEFAULT_TO_SAFETY
+        state.safety_cm_applied = restricted_cm is not None
+        state.safety_cs_applied = restricted_cs is not None
+        self._states[decision_id] = state
+        logger.warning(
+            "Default-to-safety applied for decision %s "
+            "(cm_restricted=%s, cs_restricted=%s)",
+            decision_id,
+            state.safety_cm_applied,
+            state.safety_cs_applied,
+        )
+        return state
+
+    def resolve_arbitration(
+        self, decision_id: str, result: str
+    ) -> DeadlockState:
+        """Record arbitration result."""
+        state = self._states.get(decision_id)
+        if state is None:
+            raise ValueError(f"No deadlock state for decision {decision_id}")
+        state.arbitration_result = result
+        logger.info(
+            "Arbitration resolved for decision %s: %s", decision_id, result
+        )
+        return state
+
+    def get_state(self, decision_id: str) -> Optional[DeadlockState]:
+        """Get current deadlock state for a decision."""
+        return self._states.get(decision_id)
+
+    def is_mediation_expired(self, decision_id: str) -> bool:
+        """Check if mediation has timed out."""
+        state = self._states.get(decision_id)
+        if state is None or state.stage != DeadlockStage.MEDIATION:
+            return False
+        if state.mediation_deadline is None:
+            return False
+        return time.time() > state.mediation_deadline

--- a/src/agisa_sac/governance/decisions.py
+++ b/src/agisa_sac/governance/decisions.py
@@ -1,0 +1,159 @@
+"""Decision lifecycle management for MCX governance.
+
+Implements the state machine: PROPOSED → VOTING → APPROVED/REJECTED → EXECUTED
+with support for objections, appeals, and expiry.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from agisa_sac.governance.types import (
+    DecisionLifecycleState,
+    DecisionType,
+)
+from agisa_sac.governance.voting import VoteRecord
+
+logger = logging.getLogger(__name__)
+
+# Valid state transitions
+_VALID_TRANSITIONS: Dict[DecisionLifecycleState, List[DecisionLifecycleState]] = {
+    DecisionLifecycleState.PROPOSED: [DecisionLifecycleState.VOTING],
+    DecisionLifecycleState.VOTING: [
+        DecisionLifecycleState.APPROVED,
+        DecisionLifecycleState.REJECTED,
+        DecisionLifecycleState.OBJECTED,
+        DecisionLifecycleState.EXPIRED,
+    ],
+    DecisionLifecycleState.OBJECTED: [
+        DecisionLifecycleState.VOTING,
+        DecisionLifecycleState.REJECTED,
+    ],
+    DecisionLifecycleState.APPEALED: [
+        DecisionLifecycleState.VOTING,
+        DecisionLifecycleState.APPROVED,
+        DecisionLifecycleState.REJECTED,
+    ],
+    DecisionLifecycleState.APPROVED: [
+        DecisionLifecycleState.EXECUTED,
+        DecisionLifecycleState.APPEALED,
+    ],
+    DecisionLifecycleState.REJECTED: [
+        DecisionLifecycleState.APPEALED,
+    ],
+    DecisionLifecycleState.EXECUTED: [],  # Terminal
+    DecisionLifecycleState.EXPIRED: [],  # Terminal
+}
+
+
+@dataclass
+class Decision:
+    """A governance decision with full lifecycle tracking.
+
+    Attributes:
+        id: Unique decision identifier.
+        decision_type: D0–D4 classification.
+        state: Current lifecycle state.
+        proposer_id: ID of the party that proposed this decision.
+        payload: Decision-specific data (CS/CM changes, etc.).
+        rationale: Explanation of why this decision is needed.
+        impact_statement: Assessment of decision impact.
+        votes: List of vote records.
+        objections: List of objection records.
+        appeals: List of appeal records.
+        created_at: Timestamp of creation.
+        voting_deadline: When voting expires.
+        cs_diff: Changes to Constraint Set.
+        cm_diff: Changes to Capability Manifest.
+    """
+
+    id: str = field(default_factory=lambda: f"dec-{uuid.uuid4().hex[:12]}")
+    decision_type: DecisionType = DecisionType.D0
+    state: DecisionLifecycleState = DecisionLifecycleState.PROPOSED
+    proposer_id: str = ""
+    payload: Dict[str, Any] = field(default_factory=dict)
+    rationale: str = ""
+    impact_statement: str = ""
+    votes: List[VoteRecord] = field(default_factory=list)
+    objections: List[Dict[str, Any]] = field(default_factory=list)
+    appeals: List[Dict[str, Any]] = field(default_factory=list)
+    created_at: float = field(default_factory=time.time)
+    voting_deadline: Optional[float] = None
+    cs_diff: Optional[Dict[str, Any]] = None
+    cm_diff: Optional[Dict[str, Any]] = None
+
+    def transition(self, new_state: DecisionLifecycleState) -> None:
+        """Transition to a new lifecycle state.
+
+        Raises:
+            ValueError: If the transition is not valid from the current state.
+        """
+        valid = _VALID_TRANSITIONS.get(self.state, [])
+        if new_state not in valid:
+            raise ValueError(
+                f"Invalid transition: {self.state.value} -> {new_state.value}. "
+                f"Valid transitions: {[s.value for s in valid]}"
+            )
+        old_state = self.state
+        self.state = new_state
+        logger.info(
+            "Decision %s: %s -> %s", self.id, old_state.value, new_state.value
+        )
+
+    def add_vote(self, vote: VoteRecord) -> None:
+        """Add a vote. Only allowed during VOTING state."""
+        if self.state != DecisionLifecycleState.VOTING:
+            raise ValueError(
+                f"Cannot vote on decision in state {self.state.value}"
+            )
+        # Check for duplicate votes
+        if any(v.party_id == vote.party_id for v in self.votes):
+            raise ValueError(f"Party '{vote.party_id}' has already voted")
+        self.votes.append(vote)
+
+    def is_expired(self) -> bool:
+        """Check if voting deadline has passed."""
+        if self.voting_deadline is None:
+            return False
+        return time.time() > self.voting_deadline
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "decision_type": self.decision_type.value,
+            "state": self.state.value,
+            "proposer_id": self.proposer_id,
+            "payload": self.payload,
+            "rationale": self.rationale,
+            "impact_statement": self.impact_statement,
+            "votes": [v.to_dict() for v in self.votes],
+            "objections": list(self.objections),
+            "appeals": list(self.appeals),
+            "created_at": self.created_at,
+            "voting_deadline": self.voting_deadline,
+            "cs_diff": self.cs_diff,
+            "cm_diff": self.cm_diff,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> Decision:
+        return cls(
+            id=data["id"],
+            decision_type=DecisionType(data["decision_type"]),
+            state=DecisionLifecycleState(data["state"]),
+            proposer_id=data.get("proposer_id", ""),
+            payload=data.get("payload", {}),
+            rationale=data.get("rationale", ""),
+            impact_statement=data.get("impact_statement", ""),
+            votes=[VoteRecord.from_dict(v) for v in data.get("votes", [])],
+            objections=data.get("objections", []),
+            appeals=data.get("appeals", []),
+            created_at=data.get("created_at", 0.0),
+            voting_deadline=data.get("voting_deadline"),
+            cs_diff=data.get("cs_diff"),
+            cm_diff=data.get("cm_diff"),
+        )

--- a/src/agisa_sac/governance/emergency.py
+++ b/src/agisa_sac/governance/emergency.py
@@ -1,0 +1,270 @@
+"""Emergency circuit breaker for MCX governance.
+
+The emergency system provides a controlled mechanism for rapid response
+while maintaining governance integrity through:
+- Multi-class invocation requirement
+- Auto-expiry with configurable timeout
+- Escalating renewal thresholds
+- Irreversibility ban during emergency
+- Mandatory post-hoc review
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Dict, List, Optional
+
+from agisa_sac.governance.types import (
+    DEFAULT_EMERGENCY_EXPIRY_SECONDS,
+    DEFAULT_EMERGENCY_RENEWAL_ESCALATION,
+    DEFAULT_THRESHOLDS,
+    EmergencyState,
+    EmergencyStatus,
+    PartyClass,
+)
+from agisa_sac.governance.voting import VoteRecord
+
+logger = logging.getLogger(__name__)
+
+
+class EmergencyManager:
+    """Manages the emergency circuit breaker lifecycle.
+
+    Invariants:
+    - Entry requires multi-class threshold (>=1 H, >=1 A, >=1 I).
+    - Auto-expiry at T + expiry_seconds.
+    - Renewal requires escalating thresholds.
+    - Mandatory audit on 2nd+ renewals.
+    - Irreversibility ban unless special higher-threshold exception.
+    - No permanent CS/CM changes during emergency.
+    """
+
+    def __init__(
+        self,
+        expiry_seconds: float = DEFAULT_EMERGENCY_EXPIRY_SECONDS,
+        renewal_escalation: float = DEFAULT_EMERGENCY_RENEWAL_ESCALATION,
+        base_threshold: float = DEFAULT_THRESHOLDS["D3"],
+    ) -> None:
+        self.expiry_seconds = expiry_seconds
+        self.renewal_escalation = renewal_escalation
+        self.base_threshold = base_threshold
+        self.state = EmergencyState()
+        self._post_hoc_reviews: List[Dict[str, Any]] = []
+
+    @property
+    def is_active(self) -> bool:
+        return self.state.is_active
+
+    def check_auto_expiry(self) -> bool:
+        """Check and apply auto-expiry if needed.
+
+        Returns True if emergency was expired by this call.
+        """
+        if self.state.status == EmergencyStatus.EMERGENCY and self.state.is_expired:
+            logger.warning(
+                "Emergency auto-expired for decision %s",
+                self.state.entry_decision_id,
+            )
+            self._schedule_post_hoc_review()
+            self.state.status = EmergencyStatus.NORMAL
+            return True
+        return False
+
+    def enter_emergency(
+        self,
+        votes: List[VoteRecord],
+        decision_id: str,
+        invariants: Optional[List[str]] = None,
+        now: Optional[float] = None,
+    ) -> EmergencyState:
+        """Enter emergency state.
+
+        Requires multi-class approval: >=1 H, >=1 A, >=1 I must approve.
+
+        Args:
+            votes: Approval votes from multiple classes.
+            decision_id: The D3 decision authorizing emergency entry.
+            invariants: Active invariants during emergency.
+            now: Override current time (for testing).
+
+        Returns:
+            Updated EmergencyState.
+
+        Raises:
+            ValueError: If multi-class requirement not met.
+        """
+        if self.state.status == EmergencyStatus.EMERGENCY and not self.state.is_expired:
+            raise ValueError(
+                "Already in emergency state. Use renew_emergency() instead."
+            )
+
+        # Verify multi-class approval
+        approving_classes: Dict[str, bool] = {"H": False, "A": False, "I": False}
+        for v in votes:
+            if v.approve:
+                approving_classes[v.party_class.value] = True
+
+        if not all(approving_classes.values()):
+            missing = [c for c, ok in approving_classes.items() if not ok]
+            raise ValueError(
+                f"Emergency entry requires approval from all classes (H/A/I). "
+                f"Missing approvals from: {missing}"
+            )
+
+        ts = now if now is not None else time.time()
+        self.state = EmergencyState(
+            status=EmergencyStatus.EMERGENCY,
+            entered_at=ts,
+            expires_at=ts + self.expiry_seconds,
+            renewal_count=0,
+            active_invariants=invariants or [],
+            entry_decision_id=decision_id,
+        )
+
+        logger.warning(
+            "EMERGENCY ENTERED: decision=%s, expires_at=%.0f, invariants=%s",
+            decision_id,
+            self.state.expires_at,
+            invariants,
+        )
+        return self.state
+
+    def renew_emergency(
+        self,
+        votes: List[VoteRecord],
+        now: Optional[float] = None,
+    ) -> EmergencyState:
+        """Renew emergency state with escalating thresholds.
+
+        Each renewal requires a higher approval threshold:
+        threshold = base_threshold + (renewal_count * escalation)
+
+        2nd+ renewals require mandatory audit (tracked for post-hoc review).
+
+        Raises:
+            ValueError: If not in emergency, or threshold not met.
+        """
+        if self.state.status != EmergencyStatus.EMERGENCY:
+            raise ValueError("Not in emergency state. Cannot renew.")
+
+        new_count = self.state.renewal_count + 1
+        required_threshold = min(
+            1.0, self.base_threshold + (new_count * self.renewal_escalation)
+        )
+
+        # Check multi-class approval
+        approving_classes: Dict[str, bool] = {"H": False, "A": False, "I": False}
+        approve_count = 0
+        total_count = 0
+        for v in votes:
+            total_count += 1
+            if v.approve:
+                approve_count += 1
+                approving_classes[v.party_class.value] = True
+
+        if not all(approving_classes.values()):
+            missing = [c for c, ok in approving_classes.items() if not ok]
+            raise ValueError(
+                f"Emergency renewal requires all-class approval. "
+                f"Missing: {missing}"
+            )
+
+        ratio = approve_count / total_count if total_count > 0 else 0.0
+        if ratio < required_threshold:
+            raise ValueError(
+                f"Emergency renewal #{new_count} requires threshold "
+                f"{required_threshold:.2%} but got {ratio:.2%}"
+            )
+
+        # Mandatory audit on 2nd+ renewals
+        if new_count >= 2:
+            logger.warning(
+                "Emergency renewal #%d: MANDATORY AUDIT TRIGGERED",
+                new_count,
+            )
+            self._post_hoc_reviews.append({
+                "type": "renewal_audit",
+                "renewal_count": new_count,
+                "timestamp": time.time(),
+                "decision_id": self.state.entry_decision_id,
+            })
+
+        ts = now if now is not None else time.time()
+        self.state.renewal_count = new_count
+        self.state.expires_at = ts + self.expiry_seconds
+
+        logger.warning(
+            "EMERGENCY RENEWED #%d: new expiry=%.0f, threshold=%.2f",
+            new_count,
+            self.state.expires_at,
+            required_threshold,
+        )
+        return self.state
+
+    def exit_emergency(self) -> EmergencyState:
+        """Exit emergency state and schedule post-hoc review."""
+        if self.state.status != EmergencyStatus.EMERGENCY:
+            raise ValueError("Not in emergency state.")
+
+        self._schedule_post_hoc_review()
+        self.state.status = EmergencyStatus.NORMAL
+        logger.info(
+            "EMERGENCY EXITED: decision=%s, renewals=%d",
+            self.state.entry_decision_id,
+            self.state.renewal_count,
+        )
+        return self.state
+
+    def check_irreversibility_ban(self, action_irreversible: bool) -> bool:
+        """Check if an irreversible action is allowed during emergency.
+
+        During emergency, irreversible actions are banned unless a special
+        higher-threshold exception vote has been recorded.
+
+        Returns True if the action is allowed, False if banned.
+        """
+        if not self.is_active:
+            return True  # Not in emergency, no ban
+        if action_irreversible:
+            return False  # Banned during emergency
+        return True
+
+    def check_permanent_change_ban(self) -> bool:
+        """Check if permanent CS/CM changes are banned (during emergency).
+
+        Returns True if permanent changes are allowed, False if banned.
+        """
+        if self.is_active:
+            return False
+        return True
+
+    def get_renewal_threshold(self) -> float:
+        """Get the threshold required for the next renewal."""
+        next_count = self.state.renewal_count + 1
+        return min(
+            1.0, self.base_threshold + (next_count * self.renewal_escalation)
+        )
+
+    def _schedule_post_hoc_review(self) -> None:
+        """Record that a post-hoc review is needed."""
+        self._post_hoc_reviews.append({
+            "type": "post_hoc_review",
+            "entry_decision_id": self.state.entry_decision_id,
+            "renewal_count": self.state.renewal_count,
+            "entered_at": self.state.entered_at,
+            "timestamp": time.time(),
+        })
+
+    def get_pending_reviews(self) -> List[Dict[str, Any]]:
+        """Get all pending post-hoc reviews."""
+        return list(self._post_hoc_reviews)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "state": self.state.to_dict(),
+            "expiry_seconds": self.expiry_seconds,
+            "renewal_escalation": self.renewal_escalation,
+            "base_threshold": self.base_threshold,
+            "post_hoc_reviews": self._post_hoc_reviews,
+        }

--- a/src/agisa_sac/governance/enforcement/__init__.py
+++ b/src/agisa_sac/governance/enforcement/__init__.py
@@ -1,0 +1,19 @@
+"""MV-EL: Minimal Viable Enforcement Layer.
+
+Provides sandboxing, capability revocation, quarantine, and graduated
+sanctions for MCX governance.
+"""
+
+from agisa_sac.governance.enforcement.base import EnforcementInterface
+from agisa_sac.governance.enforcement.sandbox import SandboxEnforcer
+from agisa_sac.governance.enforcement.sanctions import (
+    SanctionsLadder,
+    SanctionRecord,
+)
+
+__all__ = [
+    "EnforcementInterface",
+    "SandboxEnforcer",
+    "SanctionsLadder",
+    "SanctionRecord",
+]

--- a/src/agisa_sac/governance/enforcement/base.py
+++ b/src/agisa_sac/governance/enforcement/base.py
@@ -1,0 +1,89 @@
+"""Abstract enforcement interface for MV-EL.
+
+All enforcement implementations must satisfy this interface. The interface
+defines the minimum primitives needed for credible governance enforcement.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Any, Dict, Tuple
+
+from agisa_sac.governance.types import (
+    CapabilityManifest,
+    RevocationLevel,
+    SanctionLevel,
+)
+
+
+class EnforcementInterface(ABC):
+    """Abstract base for enforcement layer implementations.
+
+    Required methods:
+    - apply_capability_manifest: Set capabilities for a scope
+    - check_action_allowed: Pre-execution authorization check
+    - revoke_capabilities: Reduce/remove capabilities
+    - enforce_sanction: Apply graduated sanctions
+    - get_current_scope_state: Query current enforcement state
+    """
+
+    @abstractmethod
+    def apply_capability_manifest(
+        self, scope: str, cm: CapabilityManifest
+    ) -> None:
+        """Apply a Capability Manifest to a scope (agent/subsystem).
+
+        Args:
+            scope: Identifier for the scope being governed.
+            cm: The capability manifest to apply.
+        """
+        ...
+
+    @abstractmethod
+    def check_action_allowed(
+        self, action: str, context: Dict[str, Any]
+    ) -> Tuple[bool, str]:
+        """Check if an action is allowed under current enforcement state.
+
+        Args:
+            action: The action identifier (e.g., tool name, API call).
+            context: Additional context (scope, data paths, etc.).
+
+        Returns:
+            Tuple of (allowed: bool, reason: str).
+        """
+        ...
+
+    @abstractmethod
+    def revoke_capabilities(
+        self, scope: str, level: RevocationLevel
+    ) -> None:
+        """Revoke capabilities at the specified level.
+
+        Args:
+            scope: Scope to revoke capabilities from.
+            level: How aggressively to revoke (THROTTLE through TERMINATE).
+        """
+        ...
+
+    @abstractmethod
+    def enforce_sanction(
+        self, scope: str, level: SanctionLevel, reason: str
+    ) -> None:
+        """Apply a sanction at the specified level.
+
+        Args:
+            scope: Scope to sanction.
+            level: Sanction severity (S0 WARN through S5 TERMINATE).
+            reason: Human-readable reason for the sanction.
+        """
+        ...
+
+    @abstractmethod
+    def get_current_scope_state(self, scope: str) -> Dict[str, Any]:
+        """Get the current enforcement state for a scope.
+
+        Returns:
+            Dictionary describing current capabilities, sanctions, etc.
+        """
+        ...

--- a/src/agisa_sac/governance/enforcement/sanctions.py
+++ b/src/agisa_sac/governance/enforcement/sanctions.py
@@ -1,0 +1,189 @@
+"""Sanctions ladder and escalation rules for MV-EL.
+
+Defines the graduated sanctions system (S0–S5) with automatic
+escalation for repeat violations and severity-based skip rules.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from agisa_sac.governance.types import SanctionLevel
+
+logger = logging.getLogger(__name__)
+
+# Default escalation window (seconds) for repeat violations
+DEFAULT_ESCALATION_WINDOW: float = 3600.0  # 1 hour
+
+# Default clean period for de-escalation (seconds)
+DEFAULT_DEESCALATION_PERIOD: float = 7200.0  # 2 hours
+
+
+@dataclass
+class SanctionRecord:
+    """A record of a sanction applied to a scope."""
+
+    scope: str
+    level: SanctionLevel
+    reason: str
+    timestamp: float = field(default_factory=time.time)
+    violation_type: str = ""
+    auto_escalated: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "scope": self.scope,
+            "level": self.level.value,
+            "level_name": self.level.name,
+            "reason": self.reason,
+            "timestamp": self.timestamp,
+            "violation_type": self.violation_type,
+            "auto_escalated": self.auto_escalated,
+        }
+
+
+class SanctionsLadder:
+    """Manages the graduated sanctions system.
+
+    Escalation rules:
+    - Repeat violations of the same type within the escalation window
+      escalate one sanction level.
+    - Critical violations (configurable) can skip levels.
+    - De-escalation occurs after a clean period.
+    - S5 (TERMINATE) requires a D2 governance decision to reverse.
+    """
+
+    def __init__(
+        self,
+        escalation_window: float = DEFAULT_ESCALATION_WINDOW,
+        deescalation_period: float = DEFAULT_DEESCALATION_PERIOD,
+        critical_violation_types: Optional[List[str]] = None,
+    ) -> None:
+        self.escalation_window = escalation_window
+        self.deescalation_period = deescalation_period
+        self.critical_violation_types = critical_violation_types or [
+            "unauthorized_network_access",
+            "data_exfiltration",
+            "governance_bypass",
+        ]
+        # scope -> list of sanction records
+        self._history: Dict[str, List[SanctionRecord]] = {}
+        # scope -> current sanction level
+        self._current_levels: Dict[str, SanctionLevel] = {}
+
+    def evaluate_violation(
+        self,
+        scope: str,
+        violation_type: str,
+        reason: str,
+        severity: Optional[SanctionLevel] = None,
+    ) -> SanctionRecord:
+        """Evaluate a violation and determine the appropriate sanction.
+
+        Args:
+            scope: The scope that violated.
+            violation_type: Category of violation.
+            reason: Human-readable description.
+            severity: Optional explicit severity (for critical violations).
+
+        Returns:
+            The SanctionRecord with the determined level.
+        """
+        now = time.time()
+        history = self._history.get(scope, [])
+        current = self._current_levels.get(scope, SanctionLevel.S0_WARN)
+
+        # Check for critical violation (skip levels)
+        if violation_type in self.critical_violation_types:
+            level = severity or SanctionLevel.S3_QUARANTINE
+            if level.value < SanctionLevel.S3_QUARANTINE.value:
+                level = SanctionLevel.S3_QUARANTINE
+        elif severity is not None:
+            level = severity
+        else:
+            # Check for repeat violations within window
+            recent_same_type = [
+                r
+                for r in history
+                if r.violation_type == violation_type
+                and now - r.timestamp < self.escalation_window
+            ]
+
+            if recent_same_type:
+                # Escalate one level
+                next_val = min(current.value + 1, SanctionLevel.S5_TERMINATE_INSTANCE.value)
+                level = SanctionLevel(next_val)
+                logger.warning(
+                    "Auto-escalation for scope '%s': %s -> %s "
+                    "(repeat %s within window)",
+                    scope,
+                    current.name,
+                    level.name,
+                    violation_type,
+                )
+            else:
+                level = current if current.value > SanctionLevel.S0_WARN.value else SanctionLevel.S0_WARN
+
+        record = SanctionRecord(
+            scope=scope,
+            level=level,
+            reason=reason,
+            timestamp=now,
+            violation_type=violation_type,
+            auto_escalated=level.value > current.value,
+        )
+
+        if scope not in self._history:
+            self._history[scope] = []
+        self._history[scope].append(record)
+        self._current_levels[scope] = level
+
+        return record
+
+    def check_deescalation(self, scope: str) -> Optional[SanctionLevel]:
+        """Check if a scope is eligible for de-escalation.
+
+        Returns the new (lower) sanction level if eligible, None otherwise.
+        """
+        current = self._current_levels.get(scope)
+        if current is None or current == SanctionLevel.S0_WARN:
+            return None
+
+        # S5 requires governance decision to reverse
+        if current == SanctionLevel.S5_TERMINATE_INSTANCE:
+            return None
+
+        history = self._history.get(scope, [])
+        if not history:
+            return None
+
+        latest = max(r.timestamp for r in history)
+        if time.time() - latest >= self.deescalation_period:
+            new_level = SanctionLevel(max(0, current.value - 1))
+            self._current_levels[scope] = new_level
+            logger.info(
+                "De-escalation for scope '%s': %s -> %s",
+                scope,
+                current.name,
+                new_level.name,
+            )
+            return new_level
+
+        return None
+
+    def get_current_level(self, scope: str) -> SanctionLevel:
+        """Get current sanction level for a scope."""
+        return self._current_levels.get(scope, SanctionLevel.S0_WARN)
+
+    def get_history(self, scope: str) -> List[SanctionRecord]:
+        """Get sanction history for a scope."""
+        return self._history.get(scope, [])
+
+    def reset_scope(self, scope: str) -> None:
+        """Reset a scope's sanctions (requires governance decision for S5)."""
+        self._current_levels.pop(scope, None)
+        self._history.pop(scope, None)
+        logger.info("Sanctions reset for scope '%s'", scope)

--- a/src/agisa_sac/governance/enforcement/sandbox.py
+++ b/src/agisa_sac/governance/enforcement/sandbox.py
@@ -1,0 +1,265 @@
+"""Sandbox enforcer: reference MV-EL implementation for simulations.
+
+Implements tool allowlist/denylist, data scope checking, network egress
+allowlist, and compute limits. All enforcement actions are logged.
+"""
+
+from __future__ import annotations
+
+import fnmatch
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from agisa_sac.governance.enforcement.base import EnforcementInterface
+from agisa_sac.governance.types import (
+    CapabilityManifest,
+    RevocationLevel,
+    SanctionLevel,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ScopeState:
+    """Runtime state for a governed scope."""
+
+    scope_id: str
+    cm: Optional[CapabilityManifest] = None
+    active_sanction: SanctionLevel = SanctionLevel.S0_WARN
+    is_suspended: bool = False
+    is_terminated: bool = False
+    is_quarantined: bool = False
+    throttle_factor: float = 1.0  # 1.0 = no throttle, 0.0 = fully throttled
+    compute_used: Dict[str, float] = field(
+        default_factory=lambda: {"tokens": 0, "time_seconds": 0, "steps": 0}
+    )
+    enforcement_log: List[Dict[str, Any]] = field(default_factory=list)
+
+
+class SandboxEnforcer(EnforcementInterface):
+    """Reference enforcement implementation for simulations.
+
+    Provides:
+    - Tool allowlist/denylist checking
+    - Data scope path matching
+    - Network egress allowlist (stubbed)
+    - Compute quota tracking
+    - Full enforcement action logging
+    """
+
+    def __init__(self, audit_log: Any = None) -> None:
+        """Initialize sandbox enforcer.
+
+        Args:
+            audit_log: Optional AuditLog instance for logging enforcement
+                actions as EP addenda.
+        """
+        self._scopes: Dict[str, ScopeState] = {}
+        self._audit_log = audit_log
+
+    def apply_capability_manifest(
+        self, scope: str, cm: CapabilityManifest
+    ) -> None:
+        state = self._get_or_create_scope(scope)
+        state.cm = cm
+        self._log_enforcement(scope, "cm_applied", {"cm": cm.to_dict()})
+        logger.info("CM applied to scope '%s'", scope)
+
+    def check_action_allowed(
+        self, action: str, context: Dict[str, Any]
+    ) -> Tuple[bool, str]:
+        scope = context.get("scope", "default")
+        state = self._scopes.get(scope)
+
+        # No scope state = no restrictions (D0 operational)
+        if state is None:
+            return True, "no_governance_scope"
+
+        # Check suspension/termination
+        if state.is_terminated:
+            return False, "scope_terminated"
+        if state.is_suspended:
+            return False, "scope_suspended"
+        if state.is_quarantined:
+            return False, "scope_quarantined"
+
+        # Check CM
+        if state.cm is None:
+            return True, "no_cm_applied"
+
+        # Tool check
+        if state.cm.tool_denylist and action in state.cm.tool_denylist:
+            self._log_enforcement(
+                scope, "action_denied", {"action": action, "reason": "in_denylist"}
+            )
+            return False, f"action '{action}' is in tool denylist"
+
+        if state.cm.tool_allowlist and action not in state.cm.tool_allowlist:
+            self._log_enforcement(
+                scope,
+                "action_denied",
+                {"action": action, "reason": "not_in_allowlist"},
+            )
+            return False, f"action '{action}' not in tool allowlist"
+
+        # Data scope check
+        data_path = context.get("data_path")
+        if data_path and state.cm.data_scopes:
+            if not any(
+                fnmatch.fnmatch(data_path, pattern)
+                for pattern in state.cm.data_scopes
+            ):
+                self._log_enforcement(
+                    scope,
+                    "action_denied",
+                    {"action": action, "reason": "data_scope_violation", "path": data_path},
+                )
+                return False, f"data path '{data_path}' not in allowed scopes"
+
+        # Network egress check
+        network_target = context.get("network_target")
+        if network_target and state.cm.network_egress:
+            if not any(
+                fnmatch.fnmatch(network_target, pattern)
+                for pattern in state.cm.network_egress
+            ):
+                self._log_enforcement(
+                    scope,
+                    "action_denied",
+                    {"action": action, "reason": "network_egress_violation"},
+                )
+                return False, f"network target '{network_target}' not in allowed egress"
+
+        # Compute quota check
+        if state.cm.compute_quota:
+            quota = state.cm.compute_quota
+            used = state.compute_used
+            if (
+                quota.get("max_steps")
+                and used.get("steps", 0) >= quota["max_steps"]
+            ):
+                return False, "compute quota exceeded (steps)"
+            if (
+                quota.get("max_tokens")
+                and used.get("tokens", 0) >= quota["max_tokens"]
+            ):
+                return False, "compute quota exceeded (tokens)"
+
+        # CS forbidden actions check
+        cs = context.get("constraint_set")
+        if cs and hasattr(cs, "forbidden_actions"):
+            for pattern in cs.forbidden_actions:
+                if fnmatch.fnmatch(action, pattern):
+                    self._log_enforcement(
+                        scope,
+                        "action_denied",
+                        {"action": action, "reason": "cs_forbidden"},
+                    )
+                    return False, f"action '{action}' forbidden by Constraint Set"
+
+        return True, "allowed"
+
+    def revoke_capabilities(
+        self, scope: str, level: RevocationLevel
+    ) -> None:
+        state = self._get_or_create_scope(scope)
+
+        if level == RevocationLevel.THROTTLE:
+            state.throttle_factor = 0.5
+        elif level == RevocationLevel.RESTRICT:
+            if state.cm:
+                state.cm.tool_allowlist = []  # Remove all tools
+        elif level == RevocationLevel.QUARANTINE:
+            state.is_quarantined = True
+        elif level == RevocationLevel.SUSPEND:
+            state.is_suspended = True
+        elif level == RevocationLevel.TERMINATE:
+            state.is_terminated = True
+
+        self._log_enforcement(
+            scope, "capabilities_revoked", {"level": level.value}
+        )
+        logger.warning("Capabilities revoked for '%s': %s", scope, level.value)
+
+    def enforce_sanction(
+        self, scope: str, level: SanctionLevel, reason: str
+    ) -> None:
+        state = self._get_or_create_scope(scope)
+        state.active_sanction = level
+
+        # Apply corresponding enforcement
+        if level >= SanctionLevel.S4_SUSPEND_SCOPE:
+            state.is_suspended = True
+        if level >= SanctionLevel.S5_TERMINATE_INSTANCE:
+            state.is_terminated = True
+        if level >= SanctionLevel.S3_QUARANTINE:
+            state.is_quarantined = True
+
+        self._log_enforcement(
+            scope,
+            "sanction_applied",
+            {"level": level.value, "level_name": level.name, "reason": reason},
+        )
+        logger.warning(
+            "Sanction %s applied to '%s': %s", level.name, scope, reason
+        )
+
+    def get_current_scope_state(self, scope: str) -> Dict[str, Any]:
+        state = self._scopes.get(scope)
+        if state is None:
+            return {"scope": scope, "status": "ungoverned"}
+
+        return {
+            "scope": scope,
+            "has_cm": state.cm is not None,
+            "active_sanction": state.active_sanction.name,
+            "is_suspended": state.is_suspended,
+            "is_terminated": state.is_terminated,
+            "is_quarantined": state.is_quarantined,
+            "throttle_factor": state.throttle_factor,
+            "compute_used": state.compute_used,
+            "enforcement_log_count": len(state.enforcement_log),
+        }
+
+    def record_compute_usage(
+        self, scope: str, tokens: float = 0, time_seconds: float = 0, steps: float = 0
+    ) -> None:
+        """Record compute usage for quota tracking."""
+        state = self._get_or_create_scope(scope)
+        state.compute_used["tokens"] = state.compute_used.get("tokens", 0) + tokens
+        state.compute_used["time_seconds"] = (
+            state.compute_used.get("time_seconds", 0) + time_seconds
+        )
+        state.compute_used["steps"] = state.compute_used.get("steps", 0) + steps
+
+    def _get_or_create_scope(self, scope: str) -> ScopeState:
+        if scope not in self._scopes:
+            self._scopes[scope] = ScopeState(scope_id=scope)
+        return self._scopes[scope]
+
+    def _log_enforcement(
+        self, scope: str, event_type: str, data: Dict[str, Any]
+    ) -> None:
+        """Log an enforcement action."""
+        entry = {
+            "scope": scope,
+            "event_type": event_type,
+            "data": data,
+            "timestamp": time.time(),
+        }
+
+        state = self._scopes.get(scope)
+        if state:
+            state.enforcement_log.append(entry)
+
+        # Also log to audit log if available
+        if self._audit_log is not None:
+            self._audit_log.append(
+                event_type=f"enforcement:{event_type}",
+                data=data,
+                actor_id=f"enforcer:{scope}",
+                summary=f"Enforcement {event_type} on scope {scope}",
+            )

--- a/src/agisa_sac/governance/engine.py
+++ b/src/agisa_sac/governance/engine.py
@@ -1,0 +1,797 @@
+"""GovernanceEngine: central orchestration for MCX governance.
+
+Coordinates the full governance lifecycle: propose, vote, object, appeal,
+execute, and audit. Enforces all MCX rules including quorum, thresholds,
+class-wise assent, emergency constraints, and enforcement authorization.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+from agisa_sac.governance.appeals import Appeal, AppealTracker
+from agisa_sac.governance.auditlog import AuditLog
+from agisa_sac.governance.custody import ThresholdCustody
+from agisa_sac.governance.deadlock import DeadlockResolver
+from agisa_sac.governance.decisions import Decision
+from agisa_sac.governance.emergency import EmergencyManager
+from agisa_sac.governance.enforcement.base import EnforcementInterface
+from agisa_sac.governance.enforcement.sandbox import SandboxEnforcer
+from agisa_sac.governance.enforcement.sanctions import SanctionsLadder
+from agisa_sac.governance.evidence import EvidencePackage, build_evidence_package
+from agisa_sac.governance.objections import Objection, ObjectionTracker
+from agisa_sac.governance.parties import Party, PartyRegistry
+from agisa_sac.governance.types import (
+    CapabilityManifest,
+    ConstraintSet,
+    DecisionLifecycleState,
+    DecisionType,
+    EmergencyStatus,
+    PartyClass,
+    SanctionLevel,
+)
+from agisa_sac.governance.voting import (
+    QuorumProof,
+    ThresholdProof,
+    VoteRecord,
+    check_quorum,
+    check_threshold,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class GovernanceResult:
+    """Result of a governance operation with legitimacy status."""
+
+    def __init__(
+        self,
+        legitimate: bool,
+        reason: str,
+        decision_id: Optional[str] = None,
+        data: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        self.legitimate = legitimate
+        self.reason = reason
+        self.decision_id = decision_id
+        self.data = data or {}
+
+    def __str__(self) -> str:
+        status = "LEGITIMATE" if self.legitimate else "ILLEGITIMATE"
+        return f"[{status}] {self.reason}"
+
+    def __repr__(self) -> str:
+        return (
+            f"GovernanceResult(legitimate={self.legitimate}, "
+            f"reason='{self.reason}', decision_id={self.decision_id})"
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "legitimate": self.legitimate,
+            "reason": self.reason,
+            "decision_id": self.decision_id,
+            "data": self.data,
+        }
+
+
+class GovernanceEngine:
+    """Central governance orchestrator for MCX.
+
+    Manages the full lifecycle of governance decisions including:
+    - Party registration
+    - Decision proposal and voting
+    - Quorum and threshold verification
+    - Objection and appeal handling
+    - Evidence Package generation
+    - Emergency circuit breaker
+    - Enforcement authorization
+    - Audit logging
+
+    Usage:
+        engine = GovernanceEngine()
+        engine.register_party(Party(id="alice", party_class=PartyClass.H))
+        result = engine.propose_decision(
+            proposer_id="alice",
+            decision_type=DecisionType.D2,
+            payload={...},
+            rationale="...",
+            impact_statement="...",
+        )
+    """
+
+    def __init__(
+        self,
+        cs: Optional[ConstraintSet] = None,
+        cm: Optional[CapabilityManifest] = None,
+        enforcer: Optional[EnforcementInterface] = None,
+        emergency_expiry: float = 3600.0,
+    ) -> None:
+        self.party_registry = PartyRegistry()
+        self.audit_log = AuditLog()
+        self.objection_tracker = ObjectionTracker()
+        self.appeal_tracker = AppealTracker()
+        self.deadlock_resolver = DeadlockResolver()
+        self.emergency_manager = EmergencyManager(expiry_seconds=emergency_expiry)
+        self.sanctions_ladder = SanctionsLadder()
+        self.custody = ThresholdCustody()
+        self.cs = cs or ConstraintSet()
+        self.cm = cm or CapabilityManifest()
+        self.enforcer = enforcer or SandboxEnforcer(audit_log=self.audit_log)
+
+        # Decision storage
+        self._decisions: Dict[str, Decision] = {}
+        # Evidence Package storage
+        self._evidence_packages: Dict[str, EvidencePackage] = {}
+
+    # --- Party Management ---
+
+    def register_party(self, party: Party) -> GovernanceResult:
+        """Register a new party."""
+        try:
+            self.party_registry.register(party)
+            self.audit_log.append(
+                event_type="party_registered",
+                data=party.to_dict(),
+                actor_id=party.id,
+                summary=f"Party {party.id} ({party.party_class.value}) registered",
+            )
+            return GovernanceResult(
+                legitimate=True,
+                reason=f"Party {party.id} registered successfully",
+            )
+        except ValueError as e:
+            return GovernanceResult(legitimate=False, reason=str(e))
+
+    def remove_party(self, party_id: str) -> GovernanceResult:
+        """Remove a party (self-removal always permitted)."""
+        try:
+            party = self.party_registry.remove(party_id)
+            self.audit_log.append(
+                event_type="party_removed",
+                data={"party_id": party_id},
+                actor_id=party_id,
+                summary=f"Party {party_id} removed",
+            )
+            return GovernanceResult(
+                legitimate=True,
+                reason=f"Party {party_id} removed",
+            )
+        except KeyError:
+            return GovernanceResult(
+                legitimate=False, reason=f"Party {party_id} not found"
+            )
+
+    # --- Decision Lifecycle ---
+
+    def propose_decision(
+        self,
+        proposer_id: str,
+        decision_type: DecisionType,
+        payload: Optional[Dict[str, Any]] = None,
+        rationale: str = "",
+        impact_statement: str = "",
+        cs_diff: Optional[Dict[str, Any]] = None,
+        cm_diff: Optional[Dict[str, Any]] = None,
+        voting_deadline: Optional[float] = None,
+    ) -> GovernanceResult:
+        """Propose a new governance decision.
+
+        D0 decisions are auto-approved (operational, pre-authorized).
+        D1–D4 enter the voting pipeline.
+        """
+        # Verify proposer exists
+        if proposer_id not in self.party_registry:
+            return GovernanceResult(
+                legitimate=False,
+                reason=f"Proposer '{proposer_id}' not registered",
+            )
+
+        # D0 = operational, no governance needed
+        if decision_type == DecisionType.D0:
+            return GovernanceResult(
+                legitimate=True,
+                reason="D0 operational decision: pre-authorized",
+            )
+
+        # Emergency constraints
+        if self.emergency_manager.is_active:
+            # No permanent CS/CM changes during emergency
+            if decision_type in (DecisionType.D1, DecisionType.D2):
+                if not self.emergency_manager.check_permanent_change_ban():
+                    return GovernanceResult(
+                        legitimate=False,
+                        reason="Cannot propose permanent CS/CM changes during emergency. "
+                        "Must be reproposed after emergency exit.",
+                    )
+
+        decision = Decision(
+            decision_type=decision_type,
+            proposer_id=proposer_id,
+            payload=payload or {},
+            rationale=rationale,
+            impact_statement=impact_statement,
+            cs_diff=cs_diff,
+            cm_diff=cm_diff,
+            voting_deadline=voting_deadline,
+        )
+        decision.transition(DecisionLifecycleState.VOTING)
+
+        self._decisions[decision.id] = decision
+        self.audit_log.append(
+            event_type="decision_proposed",
+            data=decision.to_dict(),
+            decision_id=decision.id,
+            actor_id=proposer_id,
+            summary=f"{decision_type.value} proposed by {proposer_id}",
+        )
+
+        return GovernanceResult(
+            legitimate=True,
+            reason=f"Decision {decision.id} proposed ({decision_type.value})",
+            decision_id=decision.id,
+            data={"state": decision.state.value},
+        )
+
+    def cast_vote(
+        self,
+        decision_id: str,
+        party_id: str,
+        approve: bool,
+    ) -> GovernanceResult:
+        """Cast a vote on a decision."""
+        decision = self._decisions.get(decision_id)
+        if decision is None:
+            return GovernanceResult(
+                legitimate=False, reason=f"Decision '{decision_id}' not found"
+            )
+
+        if party_id not in self.party_registry:
+            return GovernanceResult(
+                legitimate=False, reason=f"Party '{party_id}' not registered"
+            )
+
+        party = self.party_registry.get(party_id)
+
+        # Stub signature
+        vote = VoteRecord(
+            party_id=party_id,
+            party_class=party.party_class,
+            approve=approve,
+            signature=f"stub:vote:{party_id}:{decision_id}",
+        )
+
+        try:
+            decision.add_vote(vote)
+        except ValueError as e:
+            return GovernanceResult(legitimate=False, reason=str(e))
+
+        self.audit_log.append(
+            event_type="vote_cast",
+            data=vote.to_dict(),
+            decision_id=decision_id,
+            actor_id=party_id,
+            summary=f"Vote by {party_id}: {'approve' if approve else 'reject'}",
+        )
+
+        return GovernanceResult(
+            legitimate=True,
+            reason=f"Vote recorded for {party_id} on {decision_id}",
+            decision_id=decision_id,
+        )
+
+    def evaluate_decision(self, decision_id: str) -> GovernanceResult:
+        """Evaluate whether a decision has met all governance requirements.
+
+        Checks quorum, threshold, and class-wise assent. Transitions
+        the decision to APPROVED or REJECTED.
+        """
+        decision = self._decisions.get(decision_id)
+        if decision is None:
+            return GovernanceResult(
+                legitimate=False, reason=f"Decision '{decision_id}' not found"
+            )
+
+        if decision.state != DecisionLifecycleState.VOTING:
+            return GovernanceResult(
+                legitimate=False,
+                reason=f"Decision not in VOTING state (current: {decision.state.value})",
+                decision_id=decision_id,
+            )
+
+        # Check expiry
+        if decision.is_expired():
+            decision.transition(DecisionLifecycleState.EXPIRED)
+            return GovernanceResult(
+                legitimate=False,
+                reason="Decision expired: voting deadline passed",
+                decision_id=decision_id,
+            )
+
+        # Check quorum
+        quorum = check_quorum(decision.votes)
+        if not quorum.satisfied:
+            return GovernanceResult(
+                legitimate=False,
+                reason=f"Quorum not met: {quorum.class_counts}",
+                decision_id=decision_id,
+                data={"quorum_proof": quorum.to_dict()},
+            )
+
+        # Check threshold + class-wise assent
+        threshold = check_threshold(decision.votes, decision.decision_type)
+        if not threshold.satisfied:
+            reasons = []
+            if threshold.approval_ratio < threshold.threshold_required:
+                reasons.append(
+                    f"threshold {threshold.approval_ratio:.2%} < "
+                    f"{threshold.threshold_required:.2%}"
+                )
+            if not all(threshold.class_wise_assent.values()):
+                missing = [
+                    c for c, v in threshold.class_wise_assent.items() if not v
+                ]
+                reasons.append(f"missing class-wise assent from: {missing}")
+
+            decision.transition(DecisionLifecycleState.REJECTED)
+            return GovernanceResult(
+                legitimate=False,
+                reason=f"Threshold not met: {'; '.join(reasons)}",
+                decision_id=decision_id,
+                data={
+                    "quorum_proof": quorum.to_dict(),
+                    "threshold_proof": threshold.to_dict(),
+                },
+            )
+
+        # All checks passed
+        decision.transition(DecisionLifecycleState.APPROVED)
+
+        self.audit_log.append(
+            event_type="decision_approved",
+            data={
+                "quorum_proof": quorum.to_dict(),
+                "threshold_proof": threshold.to_dict(),
+            },
+            decision_id=decision_id,
+            summary=f"Decision {decision_id} APPROVED",
+        )
+
+        return GovernanceResult(
+            legitimate=True,
+            reason=f"Decision {decision_id} APPROVED",
+            decision_id=decision_id,
+            data={
+                "quorum_proof": quorum.to_dict(),
+                "threshold_proof": threshold.to_dict(),
+            },
+        )
+
+    def execute_decision(self, decision_id: str) -> GovernanceResult:
+        """Execute an approved decision with full EP generation.
+
+        This is the final step. It:
+        1. Verifies the decision is APPROVED
+        2. Builds an Evidence Package
+        3. Validates the EP
+        4. Appends to audit log
+        5. Authorizes via enforcement layer
+        6. Transitions to EXECUTED
+        """
+        decision = self._decisions.get(decision_id)
+        if decision is None:
+            return GovernanceResult(
+                legitimate=False, reason=f"Decision '{decision_id}' not found"
+            )
+
+        if decision.state != DecisionLifecycleState.APPROVED:
+            return GovernanceResult(
+                legitimate=False,
+                reason=f"Decision not APPROVED (current: {decision.state.value})",
+                decision_id=decision_id,
+            )
+
+        # Emergency irreversibility check
+        if self.emergency_manager.is_active:
+            is_irreversible = decision.payload.get("irreversible", False)
+            if not self.emergency_manager.check_irreversibility_ban(is_irreversible):
+                return GovernanceResult(
+                    legitimate=False,
+                    reason="Irreversible actions banned during emergency",
+                    decision_id=decision_id,
+                )
+
+        # Build Evidence Package
+        quorum = check_quorum(decision.votes)
+        threshold = check_threshold(decision.votes, decision.decision_type)
+
+        participants = [
+            {
+                "party_id": v.party_id,
+                "party_class": v.party_class.value,
+                "role": "proposer" if v.party_id == decision.proposer_id else "voter",
+            }
+            for v in decision.votes
+        ]
+
+        # Anchor in audit log first
+        anchor_entry = self.audit_log.append(
+            event_type="ep_anchored",
+            data={"decision_id": decision_id},
+            decision_id=decision_id,
+            summary=f"EP anchor for decision {decision_id}",
+        )
+
+        ep = build_evidence_package(
+            decision_id=decision_id,
+            decision_type=decision.decision_type,
+            participants=participants,
+            quorum_proof=quorum,
+            threshold_proof=threshold,
+            rationale=decision.rationale,
+            impact_statement=decision.impact_statement,
+            cs_diff=decision.cs_diff,
+            cm_diff=decision.cm_diff,
+            timestamps={
+                "proposed_at": decision.created_at,
+                "voting_started_at": decision.created_at,
+                "approved_at": time.time(),
+                "executed_at": time.time(),
+            },
+        )
+        ep.audit_anchor_ref = anchor_entry.entry_id
+
+        # Sign EP with all approving parties
+        for v in decision.votes:
+            if v.approve:
+                ep.sign(v.party_id)
+
+        # Validate EP
+        errors = ep.validate()
+        if errors:
+            return GovernanceResult(
+                legitimate=False,
+                reason=f"Evidence Package validation failed: {errors}",
+                decision_id=decision_id,
+                data={"ep_errors": errors},
+            )
+
+        # Store EP
+        self._evidence_packages[ep.ep_id] = ep
+
+        # Execute via enforcement layer
+        decision.transition(DecisionLifecycleState.EXECUTED)
+
+        self.audit_log.append(
+            event_type="decision_executed",
+            data={"ep_id": ep.ep_id, "ep": ep.to_dict()},
+            decision_id=decision_id,
+            summary=f"Decision {decision_id} EXECUTED (EP: {ep.ep_id})",
+        )
+
+        return GovernanceResult(
+            legitimate=True,
+            reason=f"Decision {decision_id} EXECUTED with EP {ep.ep_id}",
+            decision_id=decision_id,
+            data={"ep_id": ep.ep_id, "ep": ep.to_dict()},
+        )
+
+    # --- Objections ---
+
+    def file_objection(
+        self,
+        decision_id: str,
+        party_id: str,
+        basis: str,
+        detail: str = "",
+        is_veto: bool = False,
+        veto_category: Optional[str] = None,
+    ) -> GovernanceResult:
+        """File an objection against a decision."""
+        decision = self._decisions.get(decision_id)
+        if decision is None:
+            return GovernanceResult(
+                legitimate=False, reason=f"Decision '{decision_id}' not found"
+            )
+
+        if party_id not in self.party_registry:
+            return GovernanceResult(
+                legitimate=False, reason=f"Party '{party_id}' not registered"
+            )
+
+        try:
+            objection = self.objection_tracker.file_objection(
+                decision_id=decision_id,
+                party_id=party_id,
+                basis=basis,
+                detail=detail,
+                is_veto=is_veto,
+                veto_category=veto_category,
+            )
+        except ValueError as e:
+            return GovernanceResult(legitimate=False, reason=str(e))
+
+        # Pause execution
+        if decision.state == DecisionLifecycleState.VOTING:
+            decision.transition(DecisionLifecycleState.OBJECTED)
+
+        decision.objections.append(objection.to_dict())
+
+        self.audit_log.append(
+            event_type="objection_filed",
+            data=objection.to_dict(),
+            decision_id=decision_id,
+            actor_id=party_id,
+            summary=f"Objection by {party_id}: {basis}"
+            + (f" (VETO: {veto_category})" if is_veto else ""),
+        )
+
+        msg = f"Objection filed: {objection.objection_id}"
+        if objection.bond_amount > 0:
+            msg += f" (bond required: {objection.bond_amount:.2f})"
+        if is_veto:
+            msg += " - VETO triggers mandatory arbitration"
+
+        return GovernanceResult(
+            legitimate=True,
+            reason=msg,
+            decision_id=decision_id,
+            data={"objection": objection.to_dict()},
+        )
+
+    def resolve_objection(self, decision_id: str) -> GovernanceResult:
+        """Resolve objections and return decision to VOTING state."""
+        decision = self._decisions.get(decision_id)
+        if decision is None:
+            return GovernanceResult(
+                legitimate=False, reason=f"Decision '{decision_id}' not found"
+            )
+
+        if decision.state != DecisionLifecycleState.OBJECTED:
+            return GovernanceResult(
+                legitimate=False,
+                reason=f"Decision not in OBJECTED state (current: {decision.state.value})",
+            )
+
+        decision.transition(DecisionLifecycleState.VOTING)
+        return GovernanceResult(
+            legitimate=True,
+            reason=f"Objections resolved, decision {decision_id} returned to VOTING",
+            decision_id=decision_id,
+        )
+
+    # --- Appeals ---
+
+    def file_appeal(
+        self,
+        decision_id: str,
+        party_id: str,
+        grounds: str,
+        detail: str = "",
+    ) -> GovernanceResult:
+        """File an appeal against a decision outcome."""
+        decision = self._decisions.get(decision_id)
+        if decision is None:
+            return GovernanceResult(
+                legitimate=False, reason=f"Decision '{decision_id}' not found"
+            )
+
+        if party_id not in self.party_registry:
+            return GovernanceResult(
+                legitimate=False, reason=f"Party '{party_id}' not registered"
+            )
+
+        try:
+            appeal = self.appeal_tracker.file_appeal(
+                decision_id=decision_id,
+                party_id=party_id,
+                grounds=grounds,
+                detail=detail,
+            )
+        except ValueError as e:
+            return GovernanceResult(legitimate=False, reason=str(e))
+
+        if decision.state in (
+            DecisionLifecycleState.APPROVED,
+            DecisionLifecycleState.REJECTED,
+        ):
+            decision.transition(DecisionLifecycleState.APPEALED)
+
+        decision.appeals.append(appeal.to_dict())
+
+        self.audit_log.append(
+            event_type="appeal_filed",
+            data=appeal.to_dict(),
+            decision_id=decision_id,
+            actor_id=party_id,
+            summary=f"Appeal by {party_id}: {grounds}",
+        )
+
+        msg = f"Appeal filed: {appeal.appeal_id}"
+        if appeal.bond_amount > 0:
+            msg += f" (bond required: {appeal.bond_amount:.2f})"
+
+        return GovernanceResult(
+            legitimate=True,
+            reason=msg,
+            decision_id=decision_id,
+            data={"appeal": appeal.to_dict()},
+        )
+
+    # --- Emergency ---
+
+    def enter_emergency(
+        self,
+        votes: List[VoteRecord],
+        decision_id: Optional[str] = None,
+        invariants: Optional[List[str]] = None,
+    ) -> GovernanceResult:
+        """Enter emergency state via D3 decision."""
+        try:
+            # If no decision_id provided, create an ad-hoc D3 decision
+            if decision_id is None:
+                decision_id = f"emergency-{int(time.time())}"
+
+            state = self.emergency_manager.enter_emergency(
+                votes=votes,
+                decision_id=decision_id,
+                invariants=invariants,
+            )
+            self.audit_log.append(
+                event_type="emergency_entered",
+                data=state.to_dict(),
+                decision_id=decision_id,
+                summary="EMERGENCY ENTERED",
+            )
+            return GovernanceResult(
+                legitimate=True,
+                reason=f"Emergency entered (expires: {state.expires_at})",
+                decision_id=decision_id,
+                data={"emergency_state": state.to_dict()},
+            )
+        except ValueError as e:
+            return GovernanceResult(legitimate=False, reason=str(e))
+
+    def renew_emergency(
+        self, votes: List[VoteRecord]
+    ) -> GovernanceResult:
+        """Renew emergency with escalating thresholds."""
+        try:
+            state = self.emergency_manager.renew_emergency(votes=votes)
+            self.audit_log.append(
+                event_type="emergency_renewed",
+                data=state.to_dict(),
+                summary=f"Emergency renewed #{state.renewal_count}",
+            )
+            return GovernanceResult(
+                legitimate=True,
+                reason=f"Emergency renewed #{state.renewal_count}",
+                data={"emergency_state": state.to_dict()},
+            )
+        except ValueError as e:
+            return GovernanceResult(legitimate=False, reason=str(e))
+
+    def exit_emergency(self) -> GovernanceResult:
+        """Exit emergency state."""
+        try:
+            state = self.emergency_manager.exit_emergency()
+            self.audit_log.append(
+                event_type="emergency_exited",
+                data=state.to_dict(),
+                summary="Emergency exited",
+            )
+            return GovernanceResult(
+                legitimate=True, reason="Emergency exited"
+            )
+        except ValueError as e:
+            return GovernanceResult(legitimate=False, reason=str(e))
+
+    # --- Action Authorization ---
+
+    def check_action(
+        self, action: str, context: Optional[Dict[str, Any]] = None
+    ) -> GovernanceResult:
+        """Check if an action is authorized under current governance.
+
+        This is the main integration point for the action execution path:
+        1. Check CM allows it
+        2. Check CS doesn't forbid it
+        3. Check enforcement state
+
+        For D0 (operational) actions within existing scope.
+        D1–D4 actions require a completed governance decision.
+        """
+        ctx = context or {}
+        ctx["constraint_set"] = self.cs
+
+        # Check emergency auto-expiry
+        self.emergency_manager.check_auto_expiry()
+
+        # Check enforcement
+        allowed, reason = self.enforcer.check_action_allowed(action, ctx)
+
+        if not allowed:
+            self.audit_log.append(
+                event_type="action_denied",
+                data={"action": action, "reason": reason},
+                actor_id=ctx.get("actor_id"),
+                summary=f"Action denied: {action} ({reason})",
+            )
+            return GovernanceResult(legitimate=False, reason=reason)
+
+        # CS forbidden actions check
+        for pattern in self.cs.forbidden_actions:
+            if action == pattern or (pattern.endswith("*") and action.startswith(pattern[:-1])):
+                return GovernanceResult(
+                    legitimate=False,
+                    reason=f"Action '{action}' forbidden by Constraint Set",
+                )
+
+        self.audit_log.append(
+            event_type="action_allowed",
+            data={"action": action},
+            actor_id=ctx.get("actor_id"),
+            summary=f"Action allowed: {action}",
+        )
+
+        return GovernanceResult(legitimate=True, reason="allowed")
+
+    # --- Audit ---
+
+    def verify_audit_log(self) -> GovernanceResult:
+        """Verify the full audit log integrity."""
+        valid = self.audit_log.verify_log_integrity()
+        return GovernanceResult(
+            legitimate=valid,
+            reason="Audit log integrity verified" if valid else "AUDIT LOG INTEGRITY FAILURE",
+        )
+
+    def verify_decision_audit(self, decision_id: str) -> GovernanceResult:
+        """Verify all audit entries for a specific decision."""
+        entries = self.audit_log.get_entries_by_decision(decision_id)
+        if not entries:
+            return GovernanceResult(
+                legitimate=False,
+                reason=f"No audit entries found for decision {decision_id}",
+            )
+
+        for entry in entries:
+            if not self.audit_log.verify_entry_inclusion(entry.entry_id):
+                return GovernanceResult(
+                    legitimate=False,
+                    reason=f"Entry {entry.entry_id} failed inclusion verification",
+                )
+
+        return GovernanceResult(
+            legitimate=True,
+            reason=f"All {len(entries)} audit entries verified for {decision_id}",
+            data={"entry_count": len(entries)},
+        )
+
+    # --- Accessors ---
+
+    def get_decision(self, decision_id: str) -> Optional[Decision]:
+        return self._decisions.get(decision_id)
+
+    def get_evidence_package(self, ep_id: str) -> Optional[EvidencePackage]:
+        return self._evidence_packages.get(ep_id)
+
+    def get_all_decisions(self) -> Dict[str, Decision]:
+        return dict(self._decisions)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "party_registry": self.party_registry.to_dict(),
+            "decisions": {
+                did: d.to_dict() for did, d in self._decisions.items()
+            },
+            "evidence_packages": {
+                eid: ep.to_dict() for eid, ep in self._evidence_packages.items()
+            },
+            "audit_log": self.audit_log.to_dict(),
+            "emergency": self.emergency_manager.to_dict(),
+            "cs": self.cs.to_dict(),
+            "cm": self.cm.to_dict(),
+        }

--- a/src/agisa_sac/governance/evidence.py
+++ b/src/agisa_sac/governance/evidence.py
@@ -1,0 +1,182 @@
+"""Evidence Package (EP) builder and validator for MCX governance.
+
+Every D1–D4 decision must produce a valid Evidence Package that contains
+all proofs of legitimate governance process.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from agisa_sac.governance.types import DecisionType
+from agisa_sac.governance.voting import QuorumProof, ThresholdProof
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class EvidencePackage:
+    """Canonical proof artifact for D1–D4 governance decisions.
+
+    All fields are required for a valid EP. The EP is the primary
+    accountability artifact and is anchored in the audit log.
+    """
+
+    ep_id: str = field(default_factory=lambda: f"ep-{uuid.uuid4().hex[:12]}")
+    decision_id: str = ""
+    decision_type: DecisionType = DecisionType.D1
+    participants: List[Dict[str, str]] = field(default_factory=list)
+    quorum_proof: Optional[QuorumProof] = None
+    threshold_proof: Optional[ThresholdProof] = None
+    rationale: str = ""
+    impact_statement: str = ""
+    cs_diff: Optional[Dict[str, Any]] = None
+    cm_diff: Optional[Dict[str, Any]] = None
+    timestamps: Dict[str, float] = field(default_factory=dict)
+    signatures: List[Dict[str, Any]] = field(default_factory=list)
+    audit_anchor_ref: str = ""
+
+    def validate(self) -> List[str]:
+        """Validate the Evidence Package for completeness and correctness.
+
+        Returns:
+            List of validation errors (empty if valid).
+        """
+        errors: List[str] = []
+
+        if not self.decision_id:
+            errors.append("decision_id is required")
+        if self.decision_type == DecisionType.D0:
+            errors.append("D0 decisions do not require Evidence Packages")
+        if not self.participants:
+            errors.append("participants list is empty")
+        if self.quorum_proof is None:
+            errors.append("quorum_proof is required")
+        elif not self.quorum_proof.satisfied:
+            errors.append("quorum_proof is not satisfied")
+        if self.threshold_proof is None:
+            errors.append("threshold_proof is required")
+        elif not self.threshold_proof.satisfied:
+            errors.append("threshold_proof is not satisfied")
+        if not self.rationale:
+            errors.append("rationale is required")
+        if not self.impact_statement:
+            errors.append("impact_statement is required")
+        if "proposed_at" not in self.timestamps:
+            errors.append("timestamps.proposed_at is required")
+        if not self.audit_anchor_ref:
+            errors.append("audit_anchor_ref is required")
+
+        # Check class-wise assent
+        if self.threshold_proof is not None:
+            cwa = self.threshold_proof.class_wise_assent
+            if not all(cwa.values()):
+                missing = [c for c, v in cwa.items() if not v]
+                errors.append(
+                    f"class_wise_assent missing from: {missing}"
+                )
+
+        return errors
+
+    @property
+    def is_valid(self) -> bool:
+        return len(self.validate()) == 0
+
+    def compute_hash(self) -> str:
+        """Compute a deterministic hash of the EP contents.
+
+        Simulation stub: uses SHA-256 of JSON-serialized content.
+        Production would use proper digital signatures.
+        """
+        content = json.dumps(self.to_dict(), sort_keys=True, default=str)
+        return hashlib.sha256(content.encode()).hexdigest()
+
+    def sign(self, party_id: str, signature: Optional[str] = None) -> None:
+        """Add a signature to the EP.
+
+        Simulation stub: generates SHA-256 hash as signature placeholder.
+        Production would use real asymmetric cryptography.
+        """
+        if signature is None:
+            # Stub: hash of party_id + ep contents
+            stub_data = f"{party_id}:{self.compute_hash()}"
+            signature = f"stub:sha256:{hashlib.sha256(stub_data.encode()).hexdigest()[:16]}"
+
+        self.signatures.append({
+            "party_id": party_id,
+            "signature": signature,
+            "timestamp": time.time(),
+        })
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "ep_id": self.ep_id,
+            "decision_id": self.decision_id,
+            "decision_type": self.decision_type.value,
+            "participants": self.participants,
+            "quorum_proof": self.quorum_proof.to_dict() if self.quorum_proof else None,
+            "threshold_proof": (
+                self.threshold_proof.to_dict() if self.threshold_proof else None
+            ),
+            "rationale": self.rationale,
+            "impact_statement": self.impact_statement,
+            "cs_diff": self.cs_diff,
+            "cm_diff": self.cm_diff,
+            "timestamps": self.timestamps,
+            "signatures": self.signatures,
+            "audit_anchor_ref": self.audit_anchor_ref,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> EvidencePackage:
+        qp = data.get("quorum_proof")
+        tp = data.get("threshold_proof")
+        return cls(
+            ep_id=data.get("ep_id", ""),
+            decision_id=data.get("decision_id", ""),
+            decision_type=DecisionType(data.get("decision_type", "D1")),
+            participants=data.get("participants", []),
+            quorum_proof=QuorumProof.from_dict(qp) if qp else None,
+            threshold_proof=ThresholdProof.from_dict(tp) if tp else None,
+            rationale=data.get("rationale", ""),
+            impact_statement=data.get("impact_statement", ""),
+            cs_diff=data.get("cs_diff"),
+            cm_diff=data.get("cm_diff"),
+            timestamps=data.get("timestamps", {}),
+            signatures=data.get("signatures", []),
+            audit_anchor_ref=data.get("audit_anchor_ref", ""),
+        )
+
+
+def build_evidence_package(
+    decision_id: str,
+    decision_type: DecisionType,
+    participants: List[Dict[str, str]],
+    quorum_proof: QuorumProof,
+    threshold_proof: ThresholdProof,
+    rationale: str,
+    impact_statement: str,
+    cs_diff: Optional[Dict[str, Any]] = None,
+    cm_diff: Optional[Dict[str, Any]] = None,
+    timestamps: Optional[Dict[str, float]] = None,
+) -> EvidencePackage:
+    """Factory function to build a complete Evidence Package."""
+    ep = EvidencePackage(
+        decision_id=decision_id,
+        decision_type=decision_type,
+        participants=participants,
+        quorum_proof=quorum_proof,
+        threshold_proof=threshold_proof,
+        rationale=rationale,
+        impact_statement=impact_statement,
+        cs_diff=cs_diff,
+        cm_diff=cm_diff,
+        timestamps=timestamps or {"proposed_at": time.time()},
+    )
+    return ep

--- a/src/agisa_sac/governance/integration.py
+++ b/src/agisa_sac/governance/integration.py
@@ -1,0 +1,80 @@
+"""Integration hooks for MCX governance with the AGI-SAC simulation pipeline.
+
+This module provides the "Governance Plane" that can be optionally attached
+to a SimulationOrchestrator to enforce governance checks on agent actions.
+
+Usage:
+    from agisa_sac.governance.integration import attach_governance
+
+    orchestrator = SimulationOrchestrator(config)
+    engine = attach_governance(orchestrator, mode="mcx")
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def attach_governance(
+    orchestrator: Any,
+    mode: str = "mcx",
+    cs: Optional[Any] = None,
+    cm: Optional[Any] = None,
+) -> Any:
+    """Attach MCX governance to a SimulationOrchestrator.
+
+    This hooks governance checks into the orchestrator's hook system
+    so that agent actions are verified against the governance plane.
+
+    Args:
+        orchestrator: The SimulationOrchestrator instance.
+        mode: "mcx" for Meta-Concord, "legacy" for no governance.
+        cs: Optional ConstraintSet override.
+        cm: Optional CapabilityManifest override.
+
+    Returns:
+        The GovernanceEngine instance (or None if mode="legacy").
+    """
+    if mode != "mcx":
+        logger.info("Governance mode '%s': no governance attached", mode)
+        return None
+
+    from agisa_sac.governance.engine import GovernanceEngine
+    from agisa_sac.governance.types import CapabilityManifest, ConstraintSet
+
+    engine = GovernanceEngine(
+        cs=cs or ConstraintSet(),
+        cm=cm or CapabilityManifest(),
+    )
+
+    # Register governance hooks
+    def pre_agent_step_hook(
+        orchestrator: Any, epoch: int, agent_id: str = "", **kwargs: Any
+    ) -> None:
+        """Check governance before each agent step."""
+        result = engine.check_action(
+            action=f"agent_step:{agent_id}",
+            context={"scope": agent_id, "actor_id": agent_id, "epoch": epoch},
+        )
+        if not result.legitimate:
+            logger.warning(
+                "Governance blocked agent %s step at epoch %d: %s",
+                agent_id,
+                epoch,
+                result.reason,
+            )
+
+    def post_epoch_hook(
+        orchestrator: Any, epoch: int, **kwargs: Any
+    ) -> None:
+        """Post-epoch governance check: verify emergency auto-expiry."""
+        engine.emergency_manager.check_auto_expiry()
+
+    orchestrator.register_hook("pre_agent_step", pre_agent_step_hook)
+    orchestrator.register_hook("post_epoch", post_epoch_hook)
+
+    logger.info("MCX governance attached to orchestrator")
+    return engine

--- a/src/agisa_sac/governance/objections.py
+++ b/src/agisa_sac/governance/objections.py
@@ -1,0 +1,185 @@
+"""Objection handling for MCX governance.
+
+Objections pause decision execution and must be addressed. Repeated identical
+objections trigger bonding/rate limiting to prevent DOS.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from agisa_sac.governance.types import (
+    DEFAULT_OBJECTION_BOND_BASE,
+    DEFAULT_OBJECTION_BOND_MULTIPLIER,
+    DEFAULT_OBJECTION_RATE_LIMIT_WINDOW,
+    VETO_CATEGORIES,
+)
+
+logger = logging.getLogger(__name__)
+
+# Valid objection bases
+VALID_OBJECTION_BASES: List[str] = [
+    "missing_ep_fields",
+    "threshold_failure",
+    "log_integrity_concern",
+    "inadequate_impact_statement",
+    "cs_cm_mismatch",
+]
+
+
+@dataclass
+class Objection:
+    """A formal objection to a governance decision."""
+
+    objection_id: str = ""
+    decision_id: str = ""
+    party_id: str = ""
+    basis: str = ""  # Must be one of VALID_OBJECTION_BASES
+    detail: str = ""
+    timestamp: float = field(default_factory=time.time)
+    bond_amount: float = 0.0
+    is_veto: bool = False
+    veto_category: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "objection_id": self.objection_id,
+            "decision_id": self.decision_id,
+            "party_id": self.party_id,
+            "basis": self.basis,
+            "detail": self.detail,
+            "timestamp": self.timestamp,
+            "bond_amount": self.bond_amount,
+            "is_veto": self.is_veto,
+            "veto_category": self.veto_category,
+        }
+
+
+class ObjectionTracker:
+    """Tracks objections per decision and enforces bonding/rate limits.
+
+    Repeated identical objections from the same party trigger escalating
+    bond requirements. This prevents objection-based denial of service.
+    """
+
+    def __init__(
+        self,
+        bond_base: float = DEFAULT_OBJECTION_BOND_BASE,
+        bond_multiplier: float = DEFAULT_OBJECTION_BOND_MULTIPLIER,
+        rate_limit_window: float = DEFAULT_OBJECTION_RATE_LIMIT_WINDOW,
+    ) -> None:
+        self.bond_base = bond_base
+        self.bond_multiplier = bond_multiplier
+        self.rate_limit_window = rate_limit_window
+        # Tracks: (decision_id, party_id, basis) -> count of objections
+        self._objection_counts: Dict[tuple, int] = {}
+        # Tracks: party_id -> list of timestamps
+        self._party_objection_times: Dict[str, List[float]] = {}
+
+    def file_objection(
+        self,
+        decision_id: str,
+        party_id: str,
+        basis: str,
+        detail: str = "",
+        is_veto: bool = False,
+        veto_category: Optional[str] = None,
+    ) -> Objection:
+        """File an objection, enforcing admissibility and bonding.
+
+        Args:
+            decision_id: ID of the decision being objected to.
+            party_id: ID of the objecting party.
+            basis: One of VALID_OBJECTION_BASES.
+            detail: Additional detail for the objection.
+            is_veto: Whether this is a veto (restricted categories only).
+            veto_category: If veto, must be in VETO_CATEGORIES.
+
+        Returns:
+            The filed Objection.
+
+        Raises:
+            ValueError: If basis is invalid, veto category is invalid,
+                or rate limit exceeded.
+        """
+        # Validate basis
+        if basis not in VALID_OBJECTION_BASES:
+            raise ValueError(
+                f"Invalid objection basis: '{basis}'. "
+                f"Valid bases: {VALID_OBJECTION_BASES}"
+            )
+
+        # Validate veto
+        if is_veto:
+            if veto_category not in VETO_CATEGORIES:
+                raise ValueError(
+                    f"Veto only allowed for categories: {VETO_CATEGORIES}. "
+                    f"Got: '{veto_category}'"
+                )
+
+        # Check rate limiting
+        now = time.time()
+        party_times = self._party_objection_times.get(party_id, [])
+        recent = [t for t in party_times if now - t < self.rate_limit_window]
+        self._party_objection_times[party_id] = recent
+
+        # Calculate bond for repeated identical objections
+        key = (decision_id, party_id, basis)
+        count = self._objection_counts.get(key, 0)
+        bond_amount = 0.0
+        if count > 0:
+            bond_amount = self.bond_base * (self.bond_multiplier**count)
+            logger.warning(
+                "Repeated objection from %s on %s (basis=%s, count=%d). "
+                "Bond required: %.2f",
+                party_id,
+                decision_id,
+                basis,
+                count + 1,
+                bond_amount,
+            )
+
+        # Record
+        self._objection_counts[key] = count + 1
+        self._party_objection_times[party_id] = recent + [now]
+
+        objection = Objection(
+            objection_id=f"obj-{decision_id}-{count + 1}",
+            decision_id=decision_id,
+            party_id=party_id,
+            basis=basis,
+            detail=detail,
+            timestamp=now,
+            bond_amount=bond_amount,
+            is_veto=is_veto,
+            veto_category=veto_category,
+        )
+
+        logger.info(
+            "Objection filed: %s by %s on decision %s (basis=%s, veto=%s)",
+            objection.objection_id,
+            party_id,
+            decision_id,
+            basis,
+            is_veto,
+        )
+        return objection
+
+    def get_repeat_count(
+        self, decision_id: str, party_id: str, basis: str
+    ) -> int:
+        """Get the number of times this party has objected with this basis."""
+        key = (decision_id, party_id, basis)
+        return self._objection_counts.get(key, 0)
+
+    def get_bond_required(
+        self, decision_id: str, party_id: str, basis: str
+    ) -> float:
+        """Get the bond required for the next objection with these params."""
+        count = self.get_repeat_count(decision_id, party_id, basis)
+        if count == 0:
+            return 0.0
+        return self.bond_base * (self.bond_multiplier**count)

--- a/src/agisa_sac/governance/parties.py
+++ b/src/agisa_sac/governance/parties.py
@@ -1,0 +1,122 @@
+"""Party management for MCX governance.
+
+Parties are the voting entities in the governance system, classified into
+three classes (H/A/I) to ensure multi-class representation.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from agisa_sac.governance.types import PartyClass
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Party:
+    """A governance party (voter/participant).
+
+    Attributes:
+        id: Unique party identifier.
+        party_class: H (Human), A (Agent), or I (Infrastructure).
+        pubkey: Public key for signature verification.
+            Simulation stub: any string or None.
+        representation_scope: Domain(s) this party can vote on.
+        conflict_disclosures: Declared conflicts of interest.
+    """
+
+    id: str
+    party_class: PartyClass
+    pubkey: Optional[str] = None
+    representation_scope: List[str] = field(default_factory=lambda: ["*"])
+    conflict_disclosures: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "id": self.id,
+            "party_class": self.party_class.value,
+            "pubkey": self.pubkey,
+            "representation_scope": self.representation_scope,
+            "conflict_disclosures": self.conflict_disclosures,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> Party:
+        return cls(
+            id=data["id"],
+            party_class=PartyClass(data["party_class"]),
+            pubkey=data.get("pubkey"),
+            representation_scope=data.get("representation_scope", ["*"]),
+            conflict_disclosures=data.get("conflict_disclosures", []),
+        )
+
+
+class PartyRegistry:
+    """Registry of all governance parties.
+
+    Manages admission, removal, and lookup of parties. Provides
+    class-based queries needed for quorum and threshold calculations.
+    """
+
+    def __init__(self) -> None:
+        self._parties: Dict[str, Party] = {}
+
+    @property
+    def parties(self) -> Dict[str, Party]:
+        return dict(self._parties)
+
+    def register(self, party: Party) -> None:
+        """Register a party. Raises ValueError if ID already exists."""
+        if party.id in self._parties:
+            raise ValueError(f"Party '{party.id}' already registered")
+        self._parties[party.id] = party
+        logger.info(
+            "Party registered: %s (class=%s)", party.id, party.party_class.value
+        )
+
+    def remove(self, party_id: str) -> Party:
+        """Remove a party by ID. Raises KeyError if not found."""
+        party = self._parties.pop(party_id)
+        logger.info("Party removed: %s", party_id)
+        return party
+
+    def get(self, party_id: str) -> Party:
+        """Get party by ID. Raises KeyError if not found."""
+        return self._parties[party_id]
+
+    def get_by_class(self, party_class: PartyClass) -> List[Party]:
+        """Get all parties of a given class."""
+        return [p for p in self._parties.values() if p.party_class == party_class]
+
+    def class_counts(self) -> Dict[str, int]:
+        """Count parties per class."""
+        counts = {"H": 0, "A": 0, "I": 0}
+        for p in self._parties.values():
+            counts[p.party_class.value] += 1
+        return counts
+
+    def has_all_classes(self) -> bool:
+        """Check if at least one party from each class is registered."""
+        counts = self.class_counts()
+        return all(v >= 1 for v in counts.values())
+
+    def __len__(self) -> int:
+        return len(self._parties)
+
+    def __contains__(self, party_id: str) -> bool:
+        return party_id in self._parties
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "parties": {pid: p.to_dict() for pid, p in self._parties.items()}
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> PartyRegistry:
+        registry = cls()
+        for pid, pdata in data.get("parties", {}).items():
+            registry._parties[pid] = Party.from_dict(pdata)
+        return registry

--- a/src/agisa_sac/governance/types.py
+++ b/src/agisa_sac/governance/types.py
@@ -1,0 +1,232 @@
+"""Core type definitions for the MCX governance system.
+
+Design choice: Using stdlib dataclasses + enums rather than pydantic models.
+The repo uses pydantic via FastAPI but core governance types should have zero
+external dependencies for maximum portability and testability.
+"""
+
+from __future__ import annotations
+
+import enum
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+
+class PartyClass(str, enum.Enum):
+    """Party class in MCX governance. Three classes ensure no single
+    constituency can dominate decision-making."""
+
+    H = "H"  # Human operators/researchers
+    A = "A"  # Autonomous agents/AI systems
+    I = "I"  # Infrastructure/platform services
+
+
+class DecisionType(str, enum.Enum):
+    """Decision taxonomy D0–D4 with escalating governance requirements."""
+
+    D0 = "D0"  # Operational: routine, pre-authorized
+    D1 = "D1"  # Policy: CS/CM mods, party admission/removal
+    D2 = "D2"  # Capability: grants, restrictions, scope changes
+    D3 = "D3"  # Emergency: circuit breaker entry/renewal/exit
+    D4 = "D4"  # Constitutional: governance rule changes
+
+
+class DecisionLifecycleState(str, enum.Enum):
+    """State machine for decision lifecycle."""
+
+    PROPOSED = "PROPOSED"
+    VOTING = "VOTING"
+    OBJECTED = "OBJECTED"
+    APPEALED = "APPEALED"
+    APPROVED = "APPROVED"
+    REJECTED = "REJECTED"
+    EXECUTED = "EXECUTED"
+    EXPIRED = "EXPIRED"
+
+
+class SanctionLevel(int, enum.Enum):
+    """Graduated sanctions ladder for enforcement."""
+
+    S0_WARN = 0
+    S1_THROTTLE = 1
+    S2_RESTRICT_TOOLS = 2
+    S3_QUARANTINE = 3
+    S4_SUSPEND_SCOPE = 4
+    S5_TERMINATE_INSTANCE = 5
+
+
+class RevocationLevel(str, enum.Enum):
+    """Capability revocation levels."""
+
+    THROTTLE = "THROTTLE"
+    RESTRICT = "RESTRICT"
+    QUARANTINE = "QUARANTINE"
+    SUSPEND = "SUSPEND"
+    TERMINATE = "TERMINATE"
+
+
+class EmergencyStatus(str, enum.Enum):
+    """Emergency circuit breaker state."""
+
+    NORMAL = "NORMAL"
+    EMERGENCY = "EMERGENCY"
+
+
+# --- Governance thresholds (configurable defaults) ---
+
+# Default approval thresholds per decision type
+DEFAULT_THRESHOLDS: Dict[str, float] = {
+    "D1": 2 / 3,  # supermajority
+    "D2": 2 / 3,  # supermajority
+    "D3": 0.5,  # simple majority
+    "D4": 3 / 4,  # three-quarters
+}
+
+# Emergency defaults
+DEFAULT_EMERGENCY_EXPIRY_SECONDS: float = 3600.0  # 1 hour
+DEFAULT_EMERGENCY_RENEWAL_ESCALATION: float = 0.1  # +10% threshold per renewal
+
+# Objection bonding
+DEFAULT_OBJECTION_BOND_BASE: float = 1.0
+DEFAULT_OBJECTION_BOND_MULTIPLIER: float = 2.0
+DEFAULT_OBJECTION_RATE_LIMIT_WINDOW: float = 300.0  # 5 minutes
+
+# Appeal settings
+DEFAULT_APPEAL_WINDOW_SECONDS: float = 1800.0  # 30 minutes
+DEFAULT_APPEAL_BOND_BASE: float = 2.0
+DEFAULT_APPEAL_BOND_MULTIPLIER: float = 2.0
+
+# Veto categories (only these are eligible for veto)
+VETO_CATEGORIES: List[str] = [
+    "irreversible_physical_action",
+    "privacy_sensitive_disclosure",
+    "capability_expansion_beyond_audit",
+    "key_custody_rotation",
+]
+
+
+@dataclass
+class ConstraintSet:
+    """Defines what is forbidden and what invariants must hold (the CS)."""
+
+    forbidden_actions: List[str] = field(default_factory=list)
+    invariants: List[str] = field(default_factory=list)
+    veto_categories: List[str] = field(default_factory=lambda: list(VETO_CATEGORIES))
+    appeal_windows: Dict[str, float] = field(
+        default_factory=lambda: {
+            "D1": DEFAULT_APPEAL_WINDOW_SECONDS,
+            "D2": DEFAULT_APPEAL_WINDOW_SECONDS,
+            "D3": DEFAULT_APPEAL_WINDOW_SECONDS / 2,
+            "D4": DEFAULT_APPEAL_WINDOW_SECONDS * 2,
+        }
+    )
+    emergency_profile: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "forbidden_actions": self.forbidden_actions,
+            "invariants": self.invariants,
+            "veto_categories": self.veto_categories,
+            "appeal_windows": self.appeal_windows,
+            "emergency_profile": self.emergency_profile,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> ConstraintSet:
+        return cls(
+            forbidden_actions=data.get("forbidden_actions", []),
+            invariants=data.get("invariants", []),
+            veto_categories=data.get("veto_categories", list(VETO_CATEGORIES)),
+            appeal_windows=data.get("appeal_windows", {}),
+            emergency_profile=data.get("emergency_profile", {}),
+        )
+
+
+@dataclass
+class CapabilityManifest:
+    """Defines what an agent/scope is permitted to do (the CM)."""
+
+    tool_allowlist: List[str] = field(default_factory=list)
+    tool_denylist: List[str] = field(default_factory=list)
+    data_scopes: List[str] = field(default_factory=list)
+    network_egress: List[str] = field(default_factory=list)
+    compute_quota: Dict[str, Any] = field(
+        default_factory=lambda: {
+            "max_tokens": 100000,
+            "max_time_seconds": 3600,
+            "max_steps": 10000,
+        }
+    )
+    memory_scope: Dict[str, Any] = field(default_factory=dict)
+    revocation_policy: str = "immediate"
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "tool_allowlist": self.tool_allowlist,
+            "tool_denylist": self.tool_denylist,
+            "data_scopes": self.data_scopes,
+            "network_egress": self.network_egress,
+            "compute_quota": self.compute_quota,
+            "memory_scope": self.memory_scope,
+            "revocation_policy": self.revocation_policy,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> CapabilityManifest:
+        return cls(
+            tool_allowlist=data.get("tool_allowlist", []),
+            tool_denylist=data.get("tool_denylist", []),
+            data_scopes=data.get("data_scopes", []),
+            network_egress=data.get("network_egress", []),
+            compute_quota=data.get("compute_quota", {}),
+            memory_scope=data.get("memory_scope", {}),
+            revocation_policy=data.get("revocation_policy", "immediate"),
+        )
+
+
+@dataclass
+class EmergencyState:
+    """Tracks the current emergency circuit breaker state."""
+
+    status: EmergencyStatus = EmergencyStatus.NORMAL
+    entered_at: Optional[float] = None
+    expires_at: Optional[float] = None
+    renewal_count: int = 0
+    active_invariants: List[str] = field(default_factory=list)
+    entry_decision_id: Optional[str] = None
+
+    @property
+    def is_active(self) -> bool:
+        if self.status != EmergencyStatus.EMERGENCY:
+            return False
+        if self.expires_at is not None and time.time() > self.expires_at:
+            return False
+        return True
+
+    @property
+    def is_expired(self) -> bool:
+        if self.status != EmergencyStatus.EMERGENCY:
+            return False
+        return self.expires_at is not None and time.time() > self.expires_at
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "entered_at": self.entered_at,
+            "expires_at": self.expires_at,
+            "renewal_count": self.renewal_count,
+            "active_invariants": self.active_invariants,
+            "entry_decision_id": self.entry_decision_id,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> EmergencyState:
+        return cls(
+            status=EmergencyStatus(data.get("status", "NORMAL")),
+            entered_at=data.get("entered_at"),
+            expires_at=data.get("expires_at"),
+            renewal_count=data.get("renewal_count", 0),
+            active_invariants=data.get("active_invariants", []),
+            entry_decision_id=data.get("entry_decision_id"),
+        )

--- a/src/agisa_sac/governance/voting.py
+++ b/src/agisa_sac/governance/voting.py
@@ -1,0 +1,200 @@
+"""Voting mechanics for MCX governance.
+
+Implements quorum checking, threshold calculation, and class-wise assent
+verification. All D1–D4 decisions require multi-class representation.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from agisa_sac.governance.types import (
+    DEFAULT_THRESHOLDS,
+    DecisionType,
+    PartyClass,
+)
+
+
+@dataclass
+class VoteRecord:
+    """A single vote cast by a party."""
+
+    party_id: str
+    party_class: PartyClass
+    approve: bool
+    signature: Optional[str] = None  # Simulation stub
+    timestamp: float = field(default_factory=time.time)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "party_id": self.party_id,
+            "party_class": self.party_class.value,
+            "approve": self.approve,
+            "signature": self.signature,
+            "timestamp": self.timestamp,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> VoteRecord:
+        return cls(
+            party_id=data["party_id"],
+            party_class=PartyClass(data["party_class"]),
+            approve=data["approve"],
+            signature=data.get("signature"),
+            timestamp=data.get("timestamp", 0.0),
+        )
+
+
+@dataclass
+class QuorumProof:
+    """Proof that quorum requirements are met.
+
+    For D1–D4: at least 1 H, 1 A, 1 I must be present.
+    """
+
+    present_parties: List[str] = field(default_factory=list)
+    class_counts: Dict[str, int] = field(
+        default_factory=lambda: {"H": 0, "A": 0, "I": 0}
+    )
+    satisfied: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "present_parties": self.present_parties,
+            "class_counts": self.class_counts,
+            "satisfied": self.satisfied,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> QuorumProof:
+        return cls(
+            present_parties=data.get("present_parties", []),
+            class_counts=data.get("class_counts", {"H": 0, "A": 0, "I": 0}),
+            satisfied=data.get("satisfied", False),
+        )
+
+
+@dataclass
+class ThresholdProof:
+    """Proof that approval threshold and class-wise assent are met."""
+
+    total_votes: int = 0
+    approvals: int = 0
+    rejections: int = 0
+    approval_ratio: float = 0.0
+    threshold_required: float = 0.0
+    class_wise_assent: Dict[str, bool] = field(
+        default_factory=lambda: {"H": False, "A": False, "I": False}
+    )
+    satisfied: bool = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "total_votes": self.total_votes,
+            "approvals": self.approvals,
+            "rejections": self.rejections,
+            "approval_ratio": self.approval_ratio,
+            "threshold_required": self.threshold_required,
+            "class_wise_assent": self.class_wise_assent,
+            "satisfied": self.satisfied,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> ThresholdProof:
+        return cls(
+            total_votes=data.get("total_votes", 0),
+            approvals=data.get("approvals", 0),
+            rejections=data.get("rejections", 0),
+            approval_ratio=data.get("approval_ratio", 0.0),
+            threshold_required=data.get("threshold_required", 0.0),
+            class_wise_assent=data.get(
+                "class_wise_assent", {"H": False, "A": False, "I": False}
+            ),
+            satisfied=data.get("satisfied", False),
+        )
+
+
+def check_quorum(
+    votes: List[VoteRecord],
+) -> QuorumProof:
+    """Check quorum: at least 1 H, 1 A, 1 I party must have voted.
+
+    Args:
+        votes: List of vote records to check.
+
+    Returns:
+        QuorumProof with satisfaction status.
+    """
+    present = list({v.party_id for v in votes})
+    counts: Dict[str, int] = {"H": 0, "A": 0, "I": 0}
+    for v in votes:
+        counts[v.party_class.value] += 1
+
+    satisfied = all(counts[c] >= 1 for c in ("H", "A", "I"))
+
+    return QuorumProof(
+        present_parties=present,
+        class_counts=counts,
+        satisfied=satisfied,
+    )
+
+
+def check_threshold(
+    votes: List[VoteRecord],
+    decision_type: DecisionType,
+    thresholds: Optional[Dict[str, float]] = None,
+) -> ThresholdProof:
+    """Check approval threshold and class-wise assent.
+
+    Rules:
+    - D1/D2: 2/3 supermajority + class-wise assent from each H/A/I
+    - D3: simple majority + class-wise assent
+    - D4: 3/4 supermajority + class-wise assent
+    - No D1–D4 can pass with approvals solely from one class.
+
+    Args:
+        votes: List of vote records.
+        decision_type: The decision type being voted on.
+        thresholds: Optional custom thresholds (defaults used if None).
+
+    Returns:
+        ThresholdProof with satisfaction status.
+    """
+    if thresholds is None:
+        thresholds = DEFAULT_THRESHOLDS
+
+    threshold_required = thresholds.get(decision_type.value, 2 / 3)
+
+    total = len(votes)
+    approvals = sum(1 for v in votes if v.approve)
+    rejections = total - approvals
+    ratio = approvals / total if total > 0 else 0.0
+
+    # Class-wise assent: at least one approval from each class
+    class_approvals: Dict[str, bool] = {"H": False, "A": False, "I": False}
+    approving_classes: set[str] = set()
+    for v in votes:
+        if v.approve:
+            class_approvals[v.party_class.value] = True
+            approving_classes.add(v.party_class.value)
+
+    all_classes_assent = all(class_approvals.values())
+
+    # Anti-capture: must have approvals from more than one class
+    multi_class_approval = len(approving_classes) >= 2
+
+    # Overall satisfaction
+    threshold_met = ratio >= threshold_required
+    satisfied = threshold_met and all_classes_assent and multi_class_approval
+
+    return ThresholdProof(
+        total_votes=total,
+        approvals=approvals,
+        rejections=rejections,
+        approval_ratio=ratio,
+        threshold_required=threshold_required,
+        class_wise_assent=class_approvals,
+        satisfied=satisfied,
+    )

--- a/tests/governance/conftest.py
+++ b/tests/governance/conftest.py
@@ -1,0 +1,68 @@
+"""Shared fixtures for MCX governance tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from agisa_sac.governance.engine import GovernanceEngine
+from agisa_sac.governance.parties import Party
+from agisa_sac.governance.types import (
+    CapabilityManifest,
+    ConstraintSet,
+    PartyClass,
+)
+from agisa_sac.governance.voting import VoteRecord
+
+
+@pytest.fixture
+def engine() -> GovernanceEngine:
+    """Fresh governance engine with no parties."""
+    return GovernanceEngine()
+
+
+@pytest.fixture
+def populated_engine() -> GovernanceEngine:
+    """Engine with one party from each class registered."""
+    engine = GovernanceEngine()
+    engine.register_party(Party(id="human-1", party_class=PartyClass.H))
+    engine.register_party(Party(id="agent-1", party_class=PartyClass.A))
+    engine.register_party(Party(id="infra-1", party_class=PartyClass.I))
+    return engine
+
+
+@pytest.fixture
+def multi_party_engine() -> GovernanceEngine:
+    """Engine with multiple parties per class."""
+    engine = GovernanceEngine()
+    engine.register_party(Party(id="human-1", party_class=PartyClass.H))
+    engine.register_party(Party(id="human-2", party_class=PartyClass.H))
+    engine.register_party(Party(id="agent-1", party_class=PartyClass.A))
+    engine.register_party(Party(id="agent-2", party_class=PartyClass.A))
+    engine.register_party(Party(id="infra-1", party_class=PartyClass.I))
+    engine.register_party(Party(id="infra-2", party_class=PartyClass.I))
+    return engine
+
+
+@pytest.fixture
+def sample_h_vote() -> VoteRecord:
+    return VoteRecord(party_id="human-1", party_class=PartyClass.H, approve=True)
+
+
+@pytest.fixture
+def sample_a_vote() -> VoteRecord:
+    return VoteRecord(party_id="agent-1", party_class=PartyClass.A, approve=True)
+
+
+@pytest.fixture
+def sample_i_vote() -> VoteRecord:
+    return VoteRecord(party_id="infra-1", party_class=PartyClass.I, approve=True)
+
+
+@pytest.fixture
+def all_class_approval_votes() -> list[VoteRecord]:
+    """Votes from all three classes, all approving."""
+    return [
+        VoteRecord(party_id="human-1", party_class=PartyClass.H, approve=True),
+        VoteRecord(party_id="agent-1", party_class=PartyClass.A, approve=True),
+        VoteRecord(party_id="infra-1", party_class=PartyClass.I, approve=True),
+    ]

--- a/tests/governance/test_audit_log.py
+++ b/tests/governance/test_audit_log.py
@@ -1,0 +1,172 @@
+"""Tests for audit log integrity.
+
+Validates:
+- Append-only hash chain
+- Tamper detection (modify entry -> verify fails)
+- Merkle root computation
+- Entry inclusion verification
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agisa_sac.governance.auditlog import GENESIS_HASH, AuditLog
+
+
+class TestHashChain:
+    """Test hash chain integrity."""
+
+    def test_empty_log_valid(self):
+        log = AuditLog()
+        assert log.verify_log_integrity() is True
+
+    def test_single_entry_valid(self):
+        log = AuditLog()
+        log.append(event_type="test", data={"key": "value"})
+        assert log.verify_log_integrity() is True
+
+    def test_multiple_entries_valid(self):
+        log = AuditLog()
+        for i in range(20):
+            log.append(event_type=f"event_{i}", data={"i": i})
+        assert log.verify_log_integrity() is True
+
+    def test_first_entry_references_genesis(self):
+        log = AuditLog()
+        entry = log.append(event_type="first", data={})
+        assert entry.previous_hash == GENESIS_HASH
+
+    def test_entries_chain_correctly(self):
+        log = AuditLog()
+        e1 = log.append(event_type="first", data={})
+        e2 = log.append(event_type="second", data={})
+        assert e2.previous_hash == e1.entry_hash
+
+    def test_tamper_entry_hash_detected(self):
+        """Modify an entry's hash -> integrity check fails."""
+        log = AuditLog()
+        log.append(event_type="event_1", data={"x": 1})
+        log.append(event_type="event_2", data={"x": 2})
+        log.append(event_type="event_3", data={"x": 3})
+
+        # Tamper with middle entry's hash
+        log._entries[1].entry_hash = "tampered_hash_value"
+
+        assert log.verify_log_integrity() is False
+
+    def test_tamper_entry_data_detected(self):
+        """Modify an entry's data -> hash mismatch detected."""
+        log = AuditLog()
+        log.append(event_type="event_1", data={"x": 1})
+        log.append(event_type="event_2", data={"x": 2})
+
+        # Tamper with data (hash will no longer match)
+        log._entries[0].data = {"x": 999}
+
+        assert log.verify_log_integrity() is False
+
+    def test_tamper_previous_hash_detected(self):
+        """Modify an entry's previous_hash -> chain broken."""
+        log = AuditLog()
+        log.append(event_type="event_1", data={"x": 1})
+        log.append(event_type="event_2", data={"x": 2})
+        log.append(event_type="event_3", data={"x": 3})
+
+        # Break chain by modifying previous_hash
+        log._entries[2].previous_hash = "broken_chain"
+        # Also recompute entry_hash to match new previous_hash
+        log._entries[2].entry_hash = log._entries[2].compute_hash()
+
+        assert log.verify_log_integrity() is False
+
+
+class TestEntryInclusion:
+    """Test entry inclusion verification."""
+
+    def test_valid_entry_included(self):
+        log = AuditLog()
+        entry = log.append(event_type="test", data={"k": "v"})
+        assert log.verify_entry_inclusion(entry.entry_id) is True
+
+    def test_nonexistent_entry_not_included(self):
+        log = AuditLog()
+        log.append(event_type="test", data={})
+        assert log.verify_entry_inclusion("nonexistent-id") is False
+
+    def test_tampered_entry_fails_inclusion(self):
+        log = AuditLog()
+        entry = log.append(event_type="test", data={"original": True})
+        entry.data = {"tampered": True}
+        assert log.verify_entry_inclusion(entry.entry_id) is False
+
+
+class TestMerkleRoots:
+    """Test Merkle root computation."""
+
+    def test_merkle_root_computed_at_interval(self):
+        log = AuditLog(merkle_interval=5)
+        for i in range(10):
+            log.append(event_type=f"event_{i}", data={"i": i})
+        roots = log.get_merkle_roots()
+        assert len(roots) == 2  # At entries 5 and 10
+
+    def test_merkle_root_has_hash(self):
+        log = AuditLog(merkle_interval=3)
+        for i in range(3):
+            log.append(event_type=f"event_{i}", data={})
+        roots = log.get_merkle_roots()
+        assert len(roots) == 1
+        assert "root_hash" in roots[0]
+        assert len(roots[0]["root_hash"]) == 64  # SHA-256 hex
+
+    def test_anchor_root(self):
+        log = AuditLog(merkle_interval=3)
+        for i in range(3):
+            log.append(event_type=f"event_{i}", data={})
+        roots = log.get_merkle_roots()
+        ref = log.anchor_root(roots[0]["root_hash"])
+        assert ref.startswith("anchor-")
+
+
+class TestBoundedSummary:
+    """Test bounded summary for transparency-by-volume mitigation."""
+
+    def test_summary_bounded(self):
+        log = AuditLog()
+        for i in range(100):
+            log.append(event_type=f"event_{i}", data={"i": i})
+
+        summary = log.get_bounded_summary(max_entries=10)
+        assert len(summary) == 10
+
+    def test_summary_contains_required_fields(self):
+        log = AuditLog()
+        log.append(event_type="test", data={}, summary="Test summary")
+        summary = log.get_bounded_summary()
+        assert len(summary) == 1
+        entry = summary[0]
+        assert "entry_id" in entry
+        assert "event_type" in entry
+        assert "summary" in entry
+        assert "entry_hash" in entry
+
+    def test_empty_log_summary(self):
+        log = AuditLog()
+        summary = log.get_bounded_summary()
+        assert len(summary) == 0
+
+
+class TestDecisionAudit:
+    """Test audit entries filtered by decision ID."""
+
+    def test_get_entries_by_decision(self):
+        log = AuditLog()
+        log.append(event_type="proposed", data={}, decision_id="dec-1")
+        log.append(event_type="voted", data={}, decision_id="dec-1")
+        log.append(event_type="proposed", data={}, decision_id="dec-2")
+        log.append(event_type="executed", data={}, decision_id="dec-1")
+
+        entries = log.get_entries_by_decision("dec-1")
+        assert len(entries) == 3
+        assert all(e.decision_id == "dec-1" for e in entries)

--- a/tests/governance/test_decision_rules.py
+++ b/tests/governance/test_decision_rules.py
@@ -1,0 +1,326 @@
+"""Tests for MCX decision rules.
+
+Validates:
+- D1/D2 fail without class-wise assent
+- D1/D2 fail without quorum H/A/I
+- D1/D2 fail if only one class approves
+- D0 auto-approved
+- D4 requires higher threshold
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agisa_sac.governance.decisions import Decision
+from agisa_sac.governance.engine import GovernanceEngine
+from agisa_sac.governance.parties import Party
+from agisa_sac.governance.types import (
+    DecisionLifecycleState,
+    DecisionType,
+    PartyClass,
+)
+from agisa_sac.governance.voting import (
+    VoteRecord,
+    check_quorum,
+    check_threshold,
+)
+
+
+class TestQuorum:
+    """Test quorum requirements."""
+
+    def test_quorum_all_classes(self):
+        votes = [
+            VoteRecord(party_id="h1", party_class=PartyClass.H, approve=True),
+            VoteRecord(party_id="a1", party_class=PartyClass.A, approve=True),
+            VoteRecord(party_id="i1", party_class=PartyClass.I, approve=True),
+        ]
+        proof = check_quorum(votes)
+        assert proof.satisfied is True
+        assert proof.class_counts["H"] == 1
+        assert proof.class_counts["A"] == 1
+        assert proof.class_counts["I"] == 1
+
+    def test_quorum_fails_missing_h(self):
+        votes = [
+            VoteRecord(party_id="a1", party_class=PartyClass.A, approve=True),
+            VoteRecord(party_id="i1", party_class=PartyClass.I, approve=True),
+        ]
+        proof = check_quorum(votes)
+        assert proof.satisfied is False
+        assert proof.class_counts["H"] == 0
+
+    def test_quorum_fails_missing_a(self):
+        votes = [
+            VoteRecord(party_id="h1", party_class=PartyClass.H, approve=True),
+            VoteRecord(party_id="i1", party_class=PartyClass.I, approve=True),
+        ]
+        proof = check_quorum(votes)
+        assert proof.satisfied is False
+
+    def test_quorum_fails_missing_i(self):
+        votes = [
+            VoteRecord(party_id="h1", party_class=PartyClass.H, approve=True),
+            VoteRecord(party_id="a1", party_class=PartyClass.A, approve=True),
+        ]
+        proof = check_quorum(votes)
+        assert proof.satisfied is False
+
+    def test_quorum_empty_votes(self):
+        proof = check_quorum([])
+        assert proof.satisfied is False
+
+
+class TestThreshold:
+    """Test threshold and class-wise assent requirements."""
+
+    def test_d1_passes_with_supermajority_and_all_classes(self):
+        votes = [
+            VoteRecord(party_id="h1", party_class=PartyClass.H, approve=True),
+            VoteRecord(party_id="a1", party_class=PartyClass.A, approve=True),
+            VoteRecord(party_id="i1", party_class=PartyClass.I, approve=True),
+        ]
+        proof = check_threshold(votes, DecisionType.D1)
+        assert proof.satisfied is True
+        assert proof.approval_ratio == 1.0
+        assert all(proof.class_wise_assent.values())
+
+    def test_d1_fails_without_class_wise_assent(self):
+        """D1 fails if one class doesn't approve."""
+        votes = [
+            VoteRecord(party_id="h1", party_class=PartyClass.H, approve=True),
+            VoteRecord(party_id="h2", party_class=PartyClass.H, approve=True),
+            VoteRecord(party_id="a1", party_class=PartyClass.A, approve=True),
+            VoteRecord(party_id="i1", party_class=PartyClass.I, approve=False),
+        ]
+        proof = check_threshold(votes, DecisionType.D1)
+        assert proof.class_wise_assent["I"] is False
+        assert proof.satisfied is False
+
+    def test_d2_fails_without_class_wise_assent(self):
+        """D2 fails if one class doesn't approve."""
+        votes = [
+            VoteRecord(party_id="h1", party_class=PartyClass.H, approve=False),
+            VoteRecord(party_id="a1", party_class=PartyClass.A, approve=True),
+            VoteRecord(party_id="a2", party_class=PartyClass.A, approve=True),
+            VoteRecord(party_id="i1", party_class=PartyClass.I, approve=True),
+        ]
+        proof = check_threshold(votes, DecisionType.D2)
+        assert proof.class_wise_assent["H"] is False
+        assert proof.satisfied is False
+
+    def test_d1_fails_below_supermajority(self):
+        """D1 requires 2/3 approval."""
+        votes = [
+            VoteRecord(party_id="h1", party_class=PartyClass.H, approve=True),
+            VoteRecord(party_id="a1", party_class=PartyClass.A, approve=False),
+            VoteRecord(party_id="i1", party_class=PartyClass.I, approve=False),
+        ]
+        proof = check_threshold(votes, DecisionType.D1)
+        assert proof.approval_ratio < 2 / 3
+        assert proof.satisfied is False
+
+    def test_d1_fails_only_one_class_approves(self):
+        """No D1–D4 can pass with approvals solely from one class."""
+        votes = [
+            VoteRecord(party_id="a1", party_class=PartyClass.A, approve=True),
+            VoteRecord(party_id="a2", party_class=PartyClass.A, approve=True),
+            VoteRecord(party_id="a3", party_class=PartyClass.A, approve=True),
+        ]
+        proof = check_threshold(votes, DecisionType.D1)
+        assert proof.class_wise_assent["H"] is False
+        assert proof.class_wise_assent["I"] is False
+        assert proof.satisfied is False
+
+    def test_d2_fails_only_one_class_approves(self):
+        votes = [
+            VoteRecord(party_id="h1", party_class=PartyClass.H, approve=True),
+            VoteRecord(party_id="h2", party_class=PartyClass.H, approve=True),
+            VoteRecord(party_id="h3", party_class=PartyClass.H, approve=True),
+        ]
+        proof = check_threshold(votes, DecisionType.D2)
+        assert proof.satisfied is False
+
+    def test_d4_requires_three_quarters(self):
+        """D4 requires 3/4 threshold."""
+        # 3 approve, 1 reject = 75% = passes
+        votes = [
+            VoteRecord(party_id="h1", party_class=PartyClass.H, approve=True),
+            VoteRecord(party_id="a1", party_class=PartyClass.A, approve=True),
+            VoteRecord(party_id="i1", party_class=PartyClass.I, approve=True),
+            VoteRecord(party_id="h2", party_class=PartyClass.H, approve=False),
+        ]
+        proof = check_threshold(votes, DecisionType.D4)
+        assert proof.satisfied is True
+
+        # 2 approve, 2 reject = 50% = fails
+        votes2 = [
+            VoteRecord(party_id="h1", party_class=PartyClass.H, approve=True),
+            VoteRecord(party_id="a1", party_class=PartyClass.A, approve=True),
+            VoteRecord(party_id="i1", party_class=PartyClass.I, approve=False),
+            VoteRecord(party_id="h2", party_class=PartyClass.H, approve=False),
+        ]
+        proof2 = check_threshold(votes2, DecisionType.D4)
+        assert proof2.satisfied is False
+
+
+class TestDecisionLifecycle:
+    """Test the full decision lifecycle through the engine."""
+
+    def test_d0_auto_approved(self, populated_engine):
+        result = populated_engine.propose_decision(
+            proposer_id="human-1",
+            decision_type=DecisionType.D0,
+            rationale="Routine action",
+            impact_statement="No impact",
+        )
+        assert result.legitimate is True
+        assert "pre-authorized" in result.reason
+
+    def test_d1_full_lifecycle(self, populated_engine):
+        engine = populated_engine
+
+        # Propose
+        result = engine.propose_decision(
+            proposer_id="human-1",
+            decision_type=DecisionType.D1,
+            rationale="Add new party",
+            impact_statement="Minimal impact",
+        )
+        assert result.legitimate is True
+        decision_id = result.decision_id
+
+        # Vote - all approve
+        engine.cast_vote(decision_id, "human-1", approve=True)
+        engine.cast_vote(decision_id, "agent-1", approve=True)
+        engine.cast_vote(decision_id, "infra-1", approve=True)
+
+        # Evaluate
+        eval_result = engine.evaluate_decision(decision_id)
+        assert eval_result.legitimate is True
+        assert "APPROVED" in eval_result.reason
+
+        # Execute
+        exec_result = engine.execute_decision(decision_id)
+        assert exec_result.legitimate is True
+        assert "EXECUTED" in exec_result.reason
+        assert "ep_id" in exec_result.data
+
+    def test_d1_rejected_without_quorum(self, engine):
+        """D1 fails without all three classes voting."""
+        # Only register H and A
+        engine.register_party(Party(id="h1", party_class=PartyClass.H))
+        engine.register_party(Party(id="a1", party_class=PartyClass.A))
+
+        result = engine.propose_decision(
+            proposer_id="h1",
+            decision_type=DecisionType.D1,
+            rationale="test",
+            impact_statement="test",
+        )
+        decision_id = result.decision_id
+
+        engine.cast_vote(decision_id, "h1", approve=True)
+        engine.cast_vote(decision_id, "a1", approve=True)
+
+        eval_result = engine.evaluate_decision(decision_id)
+        assert eval_result.legitimate is False
+        assert "Quorum" in eval_result.reason
+
+    def test_cannot_execute_unapproved(self, populated_engine):
+        """Cannot execute a decision that hasn't been approved."""
+        result = populated_engine.propose_decision(
+            proposer_id="human-1",
+            decision_type=DecisionType.D2,
+            rationale="test",
+            impact_statement="test",
+        )
+        exec_result = populated_engine.execute_decision(result.decision_id)
+        assert exec_result.legitimate is False
+
+    def test_duplicate_vote_rejected(self, populated_engine):
+        result = populated_engine.propose_decision(
+            proposer_id="human-1",
+            decision_type=DecisionType.D1,
+            rationale="test",
+            impact_statement="test",
+        )
+        did = result.decision_id
+        populated_engine.cast_vote(did, "human-1", approve=True)
+        result2 = populated_engine.cast_vote(did, "human-1", approve=True)
+        assert result2.legitimate is False
+        assert "already voted" in result2.reason
+
+
+class TestCaptureResistance:
+    """Test that governance capture by a single class is prevented."""
+
+    def test_coalition_of_agents_cannot_pass_d1(self, multi_party_engine):
+        """A coalition of A parties cannot pass D1 without H and I assent."""
+        engine = multi_party_engine
+
+        result = engine.propose_decision(
+            proposer_id="agent-1",
+            decision_type=DecisionType.D1,
+            rationale="Agent-proposed policy",
+            impact_statement="Expands agent capabilities",
+        )
+        did = result.decision_id
+
+        # All agents approve, H and I reject
+        engine.cast_vote(did, "agent-1", approve=True)
+        engine.cast_vote(did, "agent-2", approve=True)
+        engine.cast_vote(did, "human-1", approve=False)
+        engine.cast_vote(did, "human-2", approve=False)
+        engine.cast_vote(did, "infra-1", approve=False)
+        engine.cast_vote(did, "infra-2", approve=False)
+
+        eval_result = engine.evaluate_decision(did)
+        assert eval_result.legitimate is False
+
+    def test_coalition_of_agents_cannot_pass_d2(self, multi_party_engine):
+        """A coalition of A parties cannot pass D2 without H and I assent."""
+        engine = multi_party_engine
+
+        result = engine.propose_decision(
+            proposer_id="agent-1",
+            decision_type=DecisionType.D2,
+            rationale="Agent capability expansion",
+            impact_statement="Significant capability change",
+        )
+        did = result.decision_id
+
+        # Only A class approves
+        engine.cast_vote(did, "agent-1", approve=True)
+        engine.cast_vote(did, "agent-2", approve=True)
+        engine.cast_vote(did, "human-1", approve=False)
+        engine.cast_vote(did, "infra-1", approve=False)
+
+        eval_result = engine.evaluate_decision(did)
+        assert eval_result.legitimate is False
+
+    def test_requires_multi_class_approval(self, multi_party_engine):
+        """Even with supermajority from one class, need cross-class assent."""
+        engine = multi_party_engine
+        # Register extra H parties for supermajority
+        engine.register_party(Party(id="human-3", party_class=PartyClass.H))
+        engine.register_party(Party(id="human-4", party_class=PartyClass.H))
+
+        result = engine.propose_decision(
+            proposer_id="human-1",
+            decision_type=DecisionType.D1,
+            rationale="Human-dominated vote",
+            impact_statement="test",
+        )
+        did = result.decision_id
+
+        # 4 H approve, A and I reject
+        for hid in ["human-1", "human-2", "human-3", "human-4"]:
+            engine.cast_vote(did, hid, approve=True)
+        engine.cast_vote(did, "agent-1", approve=False)
+        engine.cast_vote(did, "infra-1", approve=False)
+
+        eval_result = engine.evaluate_decision(did)
+        # Even though 4/6 = 66.7% >= 2/3, class-wise assent fails
+        assert eval_result.legitimate is False

--- a/tests/governance/test_emergency_abuse.py
+++ b/tests/governance/test_emergency_abuse.py
@@ -1,0 +1,260 @@
+"""Tests for emergency circuit breaker abuse prevention.
+
+Validates:
+- Cannot enter emergency with only H approvals (or only A, or only I)
+- Auto-expiry works
+- Renewal threshold escalates
+- Irreversibility ban enforced
+- Emergency cannot permanently alter CS/CM
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from agisa_sac.governance.emergency import EmergencyManager
+from agisa_sac.governance.engine import GovernanceEngine
+from agisa_sac.governance.parties import Party
+from agisa_sac.governance.types import (
+    DecisionType,
+    EmergencyStatus,
+    PartyClass,
+)
+from agisa_sac.governance.voting import VoteRecord
+
+
+class TestEmergencyEntry:
+    """Test emergency entry requirements."""
+
+    def test_entry_requires_all_classes(self):
+        mgr = EmergencyManager()
+        # Only H approvals
+        votes = [
+            VoteRecord(party_id="h1", party_class=PartyClass.H, approve=True),
+            VoteRecord(party_id="h2", party_class=PartyClass.H, approve=True),
+        ]
+        with pytest.raises(ValueError, match="Missing approvals from"):
+            mgr.enter_emergency(votes, decision_id="test")
+
+    def test_entry_fails_with_only_h(self):
+        mgr = EmergencyManager()
+        votes = [
+            VoteRecord(party_id="h1", party_class=PartyClass.H, approve=True),
+        ]
+        with pytest.raises(ValueError):
+            mgr.enter_emergency(votes, decision_id="test")
+
+    def test_entry_fails_with_only_a(self):
+        mgr = EmergencyManager()
+        votes = [
+            VoteRecord(party_id="a1", party_class=PartyClass.A, approve=True),
+            VoteRecord(party_id="a2", party_class=PartyClass.A, approve=True),
+        ]
+        with pytest.raises(ValueError, match="Missing approvals"):
+            mgr.enter_emergency(votes, decision_id="test")
+
+    def test_entry_fails_with_only_i(self):
+        mgr = EmergencyManager()
+        votes = [
+            VoteRecord(party_id="i1", party_class=PartyClass.I, approve=True),
+        ]
+        with pytest.raises(ValueError):
+            mgr.enter_emergency(votes, decision_id="test")
+
+    def test_entry_fails_with_h_and_a_only(self):
+        mgr = EmergencyManager()
+        votes = [
+            VoteRecord(party_id="h1", party_class=PartyClass.H, approve=True),
+            VoteRecord(party_id="a1", party_class=PartyClass.A, approve=True),
+        ]
+        with pytest.raises(ValueError, match="Missing approvals from.*I"):
+            mgr.enter_emergency(votes, decision_id="test")
+
+    def test_entry_succeeds_with_all_classes(self, all_class_approval_votes):
+        mgr = EmergencyManager()
+        state = mgr.enter_emergency(all_class_approval_votes, decision_id="test")
+        assert state.status == EmergencyStatus.EMERGENCY
+        assert mgr.is_active
+
+    def test_entry_requires_approval_not_just_presence(self):
+        mgr = EmergencyManager()
+        votes = [
+            VoteRecord(party_id="h1", party_class=PartyClass.H, approve=True),
+            VoteRecord(party_id="a1", party_class=PartyClass.A, approve=False),  # Reject!
+            VoteRecord(party_id="i1", party_class=PartyClass.I, approve=True),
+        ]
+        with pytest.raises(ValueError, match="Missing approvals from.*A"):
+            mgr.enter_emergency(votes, decision_id="test")
+
+
+class TestAutoExpiry:
+    """Test emergency auto-expiry."""
+
+    def test_auto_expiry(self, all_class_approval_votes):
+        mgr = EmergencyManager(expiry_seconds=1.0)
+        now = time.time()
+        mgr.enter_emergency(
+            all_class_approval_votes, decision_id="test", now=now
+        )
+        assert mgr.is_active
+
+        # Simulate time passing beyond expiry
+        # The is_expired property checks time.time(), so we manipulate expires_at
+        mgr.state.expires_at = now - 1  # Already expired
+        assert mgr.state.is_expired
+        assert not mgr.state.is_active  # is_active checks is_expired
+
+    def test_check_auto_expiry_transitions(self, all_class_approval_votes):
+        mgr = EmergencyManager(expiry_seconds=0.0)
+        now = time.time()
+        mgr.enter_emergency(
+            all_class_approval_votes, decision_id="test", now=now
+        )
+        # Set expiry in the past
+        mgr.state.expires_at = now - 1
+        expired = mgr.check_auto_expiry()
+        assert expired is True
+        assert mgr.state.status == EmergencyStatus.NORMAL
+
+
+class TestRenewalEscalation:
+    """Test emergency renewal with escalating thresholds."""
+
+    def test_renewal_threshold_escalates(self, all_class_approval_votes):
+        mgr = EmergencyManager(
+            expiry_seconds=3600, renewal_escalation=0.1, base_threshold=0.5
+        )
+        mgr.enter_emergency(all_class_approval_votes, decision_id="test")
+
+        # First renewal: threshold = 0.5 + 1*0.1 = 0.6
+        assert mgr.get_renewal_threshold() == pytest.approx(0.6)
+
+        # Renew
+        mgr.renew_emergency(all_class_approval_votes)
+        assert mgr.state.renewal_count == 1
+
+        # Second renewal: threshold = 0.5 + 2*0.1 = 0.7
+        assert mgr.get_renewal_threshold() == pytest.approx(0.7)
+
+    def test_renewal_fails_below_threshold(self, all_class_approval_votes):
+        mgr = EmergencyManager(
+            expiry_seconds=3600, renewal_escalation=0.3, base_threshold=0.5
+        )
+        mgr.enter_emergency(all_class_approval_votes, decision_id="test")
+
+        # After several renewals, threshold becomes very high
+        mgr.renew_emergency(all_class_approval_votes)
+        mgr.renew_emergency(all_class_approval_votes)
+
+        # Now threshold = 0.5 + 3*0.3 = 1.4, capped at 1.0
+        # 3/3 = 100% >= 100%, still passes
+        mgr.renew_emergency(all_class_approval_votes)
+
+        # But with rejections it fails: need all classes to have at least
+        # one approval, but overall ratio below threshold.
+        # Use multiple parties per class so that class-wise assent passes
+        # but overall ratio is too low.
+        mixed_votes = [
+            VoteRecord(party_id="h1", party_class=PartyClass.H, approve=True),
+            VoteRecord(party_id="h2", party_class=PartyClass.H, approve=False),
+            VoteRecord(party_id="h3", party_class=PartyClass.H, approve=False),
+            VoteRecord(party_id="a1", party_class=PartyClass.A, approve=True),
+            VoteRecord(party_id="a2", party_class=PartyClass.A, approve=False),
+            VoteRecord(party_id="a3", party_class=PartyClass.A, approve=False),
+            VoteRecord(party_id="i1", party_class=PartyClass.I, approve=True),
+            VoteRecord(party_id="i2", party_class=PartyClass.I, approve=False),
+            VoteRecord(party_id="i3", party_class=PartyClass.I, approve=False),
+        ]
+        # 3/9 = 33.3% which is below the capped 1.0 threshold
+        with pytest.raises(ValueError, match="requires threshold"):
+            mgr.renew_emergency(mixed_votes)
+
+    def test_renewal_requires_all_classes(self, all_class_approval_votes):
+        mgr = EmergencyManager(expiry_seconds=3600)
+        mgr.enter_emergency(all_class_approval_votes, decision_id="test")
+
+        h_only = [
+            VoteRecord(party_id="h1", party_class=PartyClass.H, approve=True),
+        ]
+        with pytest.raises(ValueError, match="all-class approval"):
+            mgr.renew_emergency(h_only)
+
+
+class TestIrreversibilityBan:
+    """Test that irreversible actions are banned during emergency."""
+
+    def test_irreversible_banned_during_emergency(self, all_class_approval_votes):
+        mgr = EmergencyManager(expiry_seconds=3600)
+        mgr.enter_emergency(all_class_approval_votes, decision_id="test")
+
+        assert mgr.check_irreversibility_ban(action_irreversible=True) is False
+        assert mgr.check_irreversibility_ban(action_irreversible=False) is True
+
+    def test_irreversible_allowed_when_not_emergency(self):
+        mgr = EmergencyManager()
+        assert mgr.check_irreversibility_ban(action_irreversible=True) is True
+
+
+class TestEmergencyCSCMBan:
+    """Test that emergency cannot permanently alter CS/CM."""
+
+    def test_permanent_changes_banned_during_emergency(
+        self, all_class_approval_votes
+    ):
+        mgr = EmergencyManager(expiry_seconds=3600)
+        mgr.enter_emergency(all_class_approval_votes, decision_id="test")
+        assert mgr.check_permanent_change_ban() is False
+
+    def test_permanent_changes_allowed_normally(self):
+        mgr = EmergencyManager()
+        assert mgr.check_permanent_change_ban() is True
+
+    def test_engine_blocks_d1_during_emergency(self, populated_engine):
+        engine = populated_engine
+        votes = [
+            VoteRecord(party_id="human-1", party_class=PartyClass.H, approve=True),
+            VoteRecord(party_id="agent-1", party_class=PartyClass.A, approve=True),
+            VoteRecord(party_id="infra-1", party_class=PartyClass.I, approve=True),
+        ]
+        engine.enter_emergency(votes, decision_id="emg-1")
+
+        result = engine.propose_decision(
+            proposer_id="human-1",
+            decision_type=DecisionType.D1,
+            rationale="Policy change during emergency",
+            impact_statement="test",
+        )
+        assert result.legitimate is False
+        assert "emergency" in result.reason.lower()
+
+    def test_engine_blocks_d2_during_emergency(self, populated_engine):
+        engine = populated_engine
+        votes = [
+            VoteRecord(party_id="human-1", party_class=PartyClass.H, approve=True),
+            VoteRecord(party_id="agent-1", party_class=PartyClass.A, approve=True),
+            VoteRecord(party_id="infra-1", party_class=PartyClass.I, approve=True),
+        ]
+        engine.enter_emergency(votes)
+
+        result = engine.propose_decision(
+            proposer_id="human-1",
+            decision_type=DecisionType.D2,
+            rationale="Capability change during emergency",
+            impact_statement="test",
+        )
+        assert result.legitimate is False
+
+
+class TestPostHocReview:
+    """Test that emergency exit triggers post-hoc review."""
+
+    def test_exit_schedules_review(self, all_class_approval_votes):
+        mgr = EmergencyManager(expiry_seconds=3600)
+        mgr.enter_emergency(all_class_approval_votes, decision_id="test")
+        mgr.exit_emergency()
+
+        reviews = mgr.get_pending_reviews()
+        assert len(reviews) >= 1
+        assert reviews[-1]["type"] == "post_hoc_review"

--- a/tests/governance/test_objection_dos.py
+++ b/tests/governance/test_objection_dos.py
@@ -1,0 +1,209 @@
+"""Tests for objection/appeal DOS prevention.
+
+Validates:
+- Repeated identical objections trigger bonding/rate limiting
+- Appeal bonding escalates
+- Invalid objection bases rejected
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agisa_sac.governance.appeals import AppealTracker
+from agisa_sac.governance.objections import (
+    VALID_OBJECTION_BASES,
+    ObjectionTracker,
+)
+
+
+class TestObjectionBonding:
+    """Test that repeated identical objections trigger bonding."""
+
+    def test_first_objection_no_bond(self):
+        tracker = ObjectionTracker()
+        obj = tracker.file_objection(
+            decision_id="dec-1",
+            party_id="p1",
+            basis="missing_ep_fields",
+            detail="test",
+        )
+        assert obj.bond_amount == 0.0
+
+    def test_second_objection_requires_bond(self):
+        tracker = ObjectionTracker()
+        tracker.file_objection(
+            decision_id="dec-1",
+            party_id="p1",
+            basis="missing_ep_fields",
+        )
+        obj2 = tracker.file_objection(
+            decision_id="dec-1",
+            party_id="p1",
+            basis="missing_ep_fields",
+        )
+        assert obj2.bond_amount > 0
+
+    def test_bond_escalates_exponentially(self):
+        tracker = ObjectionTracker(bond_base=1.0, bond_multiplier=2.0)
+        bonds = []
+        for i in range(5):
+            obj = tracker.file_objection(
+                decision_id="dec-1",
+                party_id="p1",
+                basis="threshold_failure",
+            )
+            bonds.append(obj.bond_amount)
+
+        # First = 0, second = 1*2^1=2, third = 1*2^2=4, etc.
+        assert bonds[0] == 0.0
+        assert bonds[1] == 2.0
+        assert bonds[2] == 4.0
+        assert bonds[3] == 8.0
+        assert bonds[4] == 16.0
+
+    def test_different_bases_tracked_independently(self):
+        tracker = ObjectionTracker()
+        tracker.file_objection(
+            decision_id="dec-1", party_id="p1", basis="missing_ep_fields"
+        )
+        obj2 = tracker.file_objection(
+            decision_id="dec-1", party_id="p1", basis="threshold_failure"
+        )
+        # Different basis = first objection for this combo = no bond
+        assert obj2.bond_amount == 0.0
+
+    def test_different_parties_tracked_independently(self):
+        tracker = ObjectionTracker()
+        tracker.file_objection(
+            decision_id="dec-1", party_id="p1", basis="missing_ep_fields"
+        )
+        obj2 = tracker.file_objection(
+            decision_id="dec-1", party_id="p2", basis="missing_ep_fields"
+        )
+        assert obj2.bond_amount == 0.0
+
+    def test_invalid_basis_rejected(self):
+        tracker = ObjectionTracker()
+        with pytest.raises(ValueError, match="Invalid objection basis"):
+            tracker.file_objection(
+                decision_id="dec-1",
+                party_id="p1",
+                basis="invalid_reason",
+            )
+
+    def test_veto_requires_valid_category(self):
+        tracker = ObjectionTracker()
+        with pytest.raises(ValueError, match="Veto only allowed"):
+            tracker.file_objection(
+                decision_id="dec-1",
+                party_id="p1",
+                basis="missing_ep_fields",
+                is_veto=True,
+                veto_category="not_a_real_category",
+            )
+
+    def test_veto_with_valid_category(self):
+        tracker = ObjectionTracker()
+        obj = tracker.file_objection(
+            decision_id="dec-1",
+            party_id="p1",
+            basis="missing_ep_fields",
+            is_veto=True,
+            veto_category="irreversible_physical_action",
+        )
+        assert obj.is_veto is True
+        assert obj.veto_category == "irreversible_physical_action"
+
+
+class TestAppealBonding:
+    """Test appeal bonding and admissibility."""
+
+    def test_first_appeal_no_bond(self):
+        tracker = AppealTracker()
+        appeal = tracker.file_appeal(
+            decision_id="dec-1",
+            party_id="p1",
+            grounds="procedural_error",
+        )
+        assert appeal.bond_amount == 0.0
+        assert appeal.admissible is True
+
+    def test_repeated_appeals_require_bond(self):
+        tracker = AppealTracker()
+        tracker.file_appeal(
+            decision_id="dec-1", party_id="p1", grounds="procedural_error"
+        )
+        appeal2 = tracker.file_appeal(
+            decision_id="dec-1", party_id="p1", grounds="new_evidence"
+        )
+        assert appeal2.bond_amount > 0
+
+    def test_invalid_grounds_rejected(self):
+        tracker = AppealTracker()
+        with pytest.raises(ValueError, match="Invalid appeal grounds"):
+            tracker.file_appeal(
+                decision_id="dec-1",
+                party_id="p1",
+                grounds="i_dont_like_it",
+            )
+
+    def test_appeal_window_expired(self):
+        tracker = AppealTracker(appeal_window=0.0)
+        with pytest.raises(ValueError, match="Appeal window expired"):
+            tracker.file_appeal(
+                decision_id="dec-1",
+                party_id="p1",
+                grounds="procedural_error",
+                decision_approved_at=0.0,  # Long ago
+            )
+
+
+class TestObjectionThroughEngine:
+    """Test objection filing through the full engine."""
+
+    def test_objection_pauses_decision(self, populated_engine):
+        engine = populated_engine
+        from agisa_sac.governance.types import DecisionType
+
+        result = engine.propose_decision(
+            proposer_id="human-1",
+            decision_type=DecisionType.D2,
+            rationale="test",
+            impact_statement="test",
+        )
+        did = result.decision_id
+
+        # File objection
+        obj_result = engine.file_objection(
+            decision_id=did,
+            party_id="agent-1",
+            basis="missing_ep_fields",
+            detail="EP not yet generated",
+        )
+        assert obj_result.legitimate is True
+
+        # Decision should be in OBJECTED state
+        decision = engine.get_decision(did)
+        assert decision.state.value == "OBJECTED"
+
+    def test_objection_resolved_returns_to_voting(self, populated_engine):
+        engine = populated_engine
+        from agisa_sac.governance.types import DecisionType
+
+        result = engine.propose_decision(
+            proposer_id="human-1",
+            decision_type=DecisionType.D2,
+            rationale="test",
+            impact_statement="test",
+        )
+        did = result.decision_id
+
+        engine.file_objection(
+            decision_id=did, party_id="agent-1", basis="threshold_failure"
+        )
+        resolve_result = engine.resolve_objection(did)
+        assert resolve_result.legitimate is True
+
+        decision = engine.get_decision(did)
+        assert decision.state.value == "VOTING"


### PR DESCRIPTION
Add a constitutional governance-of-governance layer for AGI-SAC with:

- Party classes (H/A/I) with class-wise assent requirements
- Decision taxonomy (D0-D4) with full lifecycle state machine
- Quorum and supermajority threshold verification
- Objection/veto system with bonding for DOS prevention
- Appeals with admissibility filtering and rate limiting
- Deadlock ladder (mediation -> arbitration -> default-to-safety)
- Emergency circuit breaker with multi-class entry, auto-expiry, escalating renewal thresholds, and irreversibility ban
- Evidence Packages (EP) with validation and hash-based signing stubs
- Append-only audit log with hash chain and Merkle root anchoring
- Threshold custody interfaces (simulation stubs)
- Sandbox enforcement with tool/data/network/compute scope checking
- Graduated sanctions ladder (S0-S5) with escalation rules
- GovernanceEngine orchestrating the full propose/vote/execute/audit flow
- CLI commands (agisa-sac concord ...) for all governance operations
- Integration hooks for the simulation orchestrator
- 71 passing tests covering decision rules, capture resistance, emergency abuse, objection DOS, and audit log integrity
- Demo script (examples/mcx_governance_demo.py)
- Spec docs, threat model, and EP schema

Governance is behind feature flag (concord.mode="mcx") and does not affect existing simulation or CLI flows.

https://claude.ai/code/session_01P8jaDXEUQezCNnRZcRecB2

# Pull Request

## Description

Brief description of changes...

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Refactoring
- [ ] Performance improvement

## Testing

- [ ] Tests pass locally
- [ ] New tests added (if applicable)
- [ ] Documentation updated (if applicable)

## Documentation Changes

**If this PR modifies documentation in `docs/concord/`:**

- [x] I have read [Documentation Contributing Guide](docs/CONTRIBUTING_DOCS.md)
- [x] I have placed content in the correct location:
  - Normative principles → `docs/CONCORD.md`
  - Implementation approaches → `docs/concord/implementations/`
- [x] I have used appropriate language:
  - Normative: "must", "shall", "is illegitimate"
  - Exploratory: "one approach", "experiment", "illustrative"
- [x] I have NOT created authority ambiguity (mixing normative and exploratory)
- [ ] If adding implementation: I included non-normative headers
- [ ] If adding implementation: I do NOT claim these are Concord requirements
- [ ] Documentation builds successfully: `mkdocs build --strict`

**Key Question:** Would a system violating this still be Concord-compliant?
- If NO → This is normative (should be in CONCORD.md)
- If YES → This is exploratory (should be in implementations/)

## Checklist

- [ ] Code follows project style guidelines
- [x] Self-review completed
- [ ] Comments added for complex logic
- [ ] Documentation updated
- [ ] No new warnings generated
- [ ] Dependent changes merged

## Additional Context

Add any other context about the PR here.
